### PR TITLE
feat: M2 unified engine with mode-based latency

### DIFF
--- a/src/xpyd_sim/cli.py
+++ b/src/xpyd_sim/cli.py
@@ -8,12 +8,36 @@ import argparse
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="xpyd-sim", description="xPyD inference simulator")
     sub = parser.add_subparsers(dest="command")
-    p = sub.add_parser("prefill", help="Start prefill node")
-    p.add_argument("--port", type=int, default=8001)
-    d = sub.add_parser("decode", help="Start decode node")
-    d.add_argument("--port", type=int, default=8002)
+
+    serve = sub.add_parser("serve", help="Start the unified simulator server")
+    serve.add_argument("--mode", choices=["dual", "prefill", "decode"], default="dual")
+    serve.add_argument("--port", type=int, default=8000)
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--model", default="dummy")
+    serve.add_argument("--prefill-delay-ms", type=float, default=50.0)
+    serve.add_argument("--kv-transfer-delay-ms", type=float, default=5.0)
+    serve.add_argument("--decode-delay-per-token-ms", type=float, default=10.0)
+    serve.add_argument("--eos-min-ratio", type=float, default=0.5)
+    serve.add_argument("--max-model-len", type=int, default=131072)
+
     args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
         return
-    print(f"xpyd-sim {args.command} — not yet implemented")
+
+    if args.command == "serve":
+        import uvicorn
+
+        from xpyd_sim.server import ServerConfig, create_app
+
+        config = ServerConfig(
+            mode=args.mode,
+            model_name=args.model,
+            prefill_delay_ms=args.prefill_delay_ms,
+            kv_transfer_delay_ms=args.kv_transfer_delay_ms,
+            decode_delay_per_token_ms=args.decode_delay_per_token_ms,
+            eos_min_ratio=args.eos_min_ratio,
+            max_model_len=args.max_model_len,
+        )
+        app = create_app(config)
+        uvicorn.run(app, host=args.host, port=args.port)

--- a/src/xpyd_sim/common/models.py
+++ b/src/xpyd_sim/common/models.py
@@ -145,6 +145,7 @@ class ModelCard(BaseModel):
     object: str = "model"
     created: int = 0
     owned_by: str = "xpyd-sim"
+    max_model_len: Optional[int] = None
 
 
 class ModelListResponse(BaseModel):

--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -1,0 +1,497 @@
+"""Unified FastAPI server for xPyD-sim with mode-based latency."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import random
+from dataclasses import dataclass
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from pydantic import ValidationError
+
+from xpyd_sim.common.helpers import (
+    count_prompt_tokens,
+    generate_id,
+    get_effective_max_tokens,
+    now_ts,
+    render_dummy_text,
+)
+from xpyd_sim.common.models import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    Choice,
+    ChoiceMessage,
+    CompletionChoice,
+    CompletionChunk,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionStreamChoice,
+    DeltaMessage,
+    ModelCard,
+    ModelListResponse,
+    StreamChoice,
+    UsageInfo,
+)
+
+SYSTEM_FINGERPRINT = "fp_xpyd_sim"
+
+
+@dataclass
+class ServerConfig:
+    """Server configuration."""
+
+    mode: str = "dual"  # dual, prefill, decode
+    model_name: str = "dummy"
+    prefill_delay_ms: float = 50.0
+    kv_transfer_delay_ms: float = 5.0
+    decode_delay_per_token_ms: float = 10.0
+    eos_min_ratio: float = 0.5
+    max_model_len: int = 131072
+    default_max_tokens: int = 16
+
+
+def _compute_output_length(
+    max_tokens: int,
+    eos_min_ratio: float,
+    ignore_eos: bool,
+) -> tuple[int, str]:
+    """Return (num_tokens, finish_reason)."""
+    if ignore_eos or max_tokens <= 1:
+        return max_tokens, "length"
+    min_len = max(1, math.ceil(max_tokens * eos_min_ratio))
+    actual = random.randint(min_len, max_tokens)
+    if actual < max_tokens:
+        return actual, "stop"
+    return max_tokens, "length"
+
+
+def _check_stop_sequences(text: str, stop: str | list[str] | None) -> tuple[str, bool]:
+    """Check text for stop sequences. Returns (possibly_truncated_text, was_stopped)."""
+    if stop is None:
+        return text, False
+    if isinstance(stop, str):
+        stop = [stop]
+    earliest_pos = len(text)
+    found = False
+    for seq in stop:
+        pos = text.find(seq)
+        if pos != -1 and pos < earliest_pos:
+            earliest_pos = pos
+            found = True
+    if found:
+        return text[:earliest_pos], True
+    return text, False
+
+
+def _compute_prefill_delay(config: ServerConfig, prompt_tokens: int) -> float:
+    """Prefill delay in seconds based on mode."""
+    if config.mode == "decode":
+        return 0.0
+    return config.prefill_delay_ms / 1000.0
+
+
+def _compute_kv_delay(config: ServerConfig) -> float:
+    """KV transfer delay in seconds based on mode."""
+    if config.mode == "dual":
+        return 0.0  # local, no transfer
+    if config.mode == "prefill":
+        return 0.0  # prefill doesn't wait for KV
+    # decode mode: wait for KV
+    return config.kv_transfer_delay_ms / 1000.0
+
+
+def _compute_decode_delay(config: ServerConfig) -> float:
+    """Per-token decode delay in seconds."""
+    return config.decode_delay_per_token_ms / 1000.0
+
+
+def create_app(config: ServerConfig | None = None) -> FastAPI:
+    """Create the unified xPyD-sim FastAPI application."""
+    if config is None:
+        config = ServerConfig()
+
+    app = FastAPI(title="xPyD-sim")
+    app.state.config = config
+
+    @app.exception_handler(ValidationError)
+    async def validation_exception_handler(request: Request, exc: ValidationError):
+        return JSONResponse(
+            status_code=400,
+            content={"error": {"message": str(exc), "type": "invalid_request_error"}},
+        )
+
+    @app.get("/ping")
+    @app.post("/ping")
+    async def ping():
+        return PlainTextResponse("pong")
+
+    @app.get("/health")
+    async def health():
+        return {
+            "status": "ok",
+            "mode": config.mode,
+            "model": config.model_name,
+            "config": {
+                "prefill_delay_ms": config.prefill_delay_ms,
+                "kv_transfer_delay_ms": config.kv_transfer_delay_ms,
+                "decode_delay_per_token_ms": config.decode_delay_per_token_ms,
+            },
+        }
+
+    @app.get("/v1/models")
+    async def list_models():
+        card = ModelCard(
+            id=config.model_name,
+            created=now_ts(),
+            max_model_len=config.max_model_len,
+        )
+        return ModelListResponse(data=[card])
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {"message": "Invalid JSON body", "type": "invalid_request_error"}
+                },
+            )
+        if "messages" not in body:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "message": "Missing required field: messages",
+                        "type": "invalid_request_error",
+                    }
+                },
+            )
+
+        try:
+            req = ChatCompletionRequest(**body)
+        except ValidationError as e:
+            return JSONResponse(
+                status_code=400,
+                content={"error": {"message": str(e), "type": "invalid_request_error"}},
+            )
+
+        prompt_tokens = count_prompt_tokens(messages=req.messages)
+        max_tokens = get_effective_max_tokens(req.max_completion_tokens, req.max_tokens)
+        n = req.n or 1
+        ignore_eos = req.ignore_eos or False
+
+        # Simulate prefill + KV transfer
+        prefill_delay = _compute_prefill_delay(config, prompt_tokens)
+        kv_delay = _compute_kv_delay(config)
+        await asyncio.sleep(prefill_delay + kv_delay)
+
+        if req.stream:
+            return StreamingResponse(
+                _stream_chat(config, req, prompt_tokens, max_tokens, n, ignore_eos),
+                media_type="text/event-stream",
+            )
+
+        # Non-streaming
+        choices = []
+        total_completion = 0
+        for i in range(n):
+            num_tokens, finish_reason = _compute_output_length(
+                max_tokens, config.eos_min_ratio, ignore_eos
+            )
+            text = render_dummy_text(num_tokens)
+            text, stopped = _check_stop_sequences(text, req.stop)
+            if stopped:
+                finish_reason = "stop"
+                num_tokens = max(1, len(text) // 4)
+            total_completion += num_tokens
+            choices.append(
+                Choice(
+                    index=i,
+                    message=ChoiceMessage(role="assistant", content=text),
+                    finish_reason=finish_reason,
+                    logprobs=None,
+                )
+            )
+
+        # Simulate decode delay
+        decode_delay = _compute_decode_delay(config)
+        await asyncio.sleep(decode_delay * total_completion)
+
+        return ChatCompletionResponse(
+            id=generate_id("chatcmpl"),
+            created=now_ts(),
+            model=config.model_name,
+            choices=choices,
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion,
+                total_tokens=prompt_tokens + total_completion,
+            ),
+            system_fingerprint=SYSTEM_FINGERPRINT,
+        )
+
+    @app.post("/v1/completions")
+    async def completions(request: Request):
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {"message": "Invalid JSON body", "type": "invalid_request_error"}
+                },
+            )
+        try:
+            req = CompletionRequest(**body)
+        except ValidationError as e:
+            return JSONResponse(
+                status_code=400,
+                content={"error": {"message": str(e), "type": "invalid_request_error"}},
+            )
+
+        prompt_tokens = count_prompt_tokens(prompt=req.prompt)
+        max_tokens = get_effective_max_tokens(req.max_tokens)
+        n = req.n or 1
+        ignore_eos = req.ignore_eos or False
+
+        # Simulate prefill + KV transfer
+        prefill_delay = _compute_prefill_delay(config, prompt_tokens)
+        kv_delay = _compute_kv_delay(config)
+        await asyncio.sleep(prefill_delay + kv_delay)
+
+        if req.stream:
+            return StreamingResponse(
+                _stream_completion(config, req, prompt_tokens, max_tokens, n, ignore_eos),
+                media_type="text/event-stream",
+            )
+
+        # Non-streaming
+        choices = []
+        total_completion = 0
+        for i in range(n):
+            num_tokens, finish_reason = _compute_output_length(
+                max_tokens, config.eos_min_ratio, ignore_eos
+            )
+            text = render_dummy_text(num_tokens)
+            text, stopped = _check_stop_sequences(text, req.stop)
+            if stopped:
+                finish_reason = "stop"
+                num_tokens = max(1, len(text) // 4)
+            total_completion += num_tokens
+            choices.append(
+                CompletionChoice(
+                    index=i,
+                    text=text,
+                    finish_reason=finish_reason,
+                    logprobs=None,
+                )
+            )
+
+        # Simulate decode delay
+        decode_delay = _compute_decode_delay(config)
+        await asyncio.sleep(decode_delay * total_completion)
+
+        return CompletionResponse(
+            id=generate_id("cmpl"),
+            created=now_ts(),
+            model=config.model_name,
+            choices=choices,
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion,
+                total_tokens=prompt_tokens + total_completion,
+            ),
+            system_fingerprint=SYSTEM_FINGERPRINT,
+        )
+
+    return app
+
+
+async def _stream_chat(
+    config: ServerConfig,
+    req: ChatCompletionRequest,
+    prompt_tokens: int,
+    max_tokens: int,
+    n: int,
+    ignore_eos: bool,
+):
+    """Stream chat completion chunks with per-token decode delay."""
+    req_id = generate_id("chatcmpl")
+    created = now_ts()
+    include_usage = req.stream_options.get("include_usage", False) if req.stream_options else False
+    decode_delay = _compute_decode_delay(config)
+    total_completion = 0
+
+    for idx in range(n):
+        num_tokens, finish_reason = _compute_output_length(
+            max_tokens, config.eos_min_ratio, ignore_eos
+        )
+        text = render_dummy_text(num_tokens)
+
+        # First chunk: role
+        chunk = ChatCompletionChunk(
+            id=req_id,
+            created=created,
+            model=config.model_name,
+            choices=[
+                StreamChoice(
+                    index=idx,
+                    delta=DeltaMessage(role="assistant", content=""),
+                    logprobs=None,
+                )
+            ],
+            system_fingerprint=SYSTEM_FINGERPRINT,
+        )
+        yield f"data: {chunk.model_dump_json()}\n\n"
+
+        # Content chunks (per character as token proxy)
+        emitted = ""
+        for char in text:
+            emitted += char
+            # Check stop sequences
+            if req.stop:
+                _, was_stopped = _check_stop_sequences(emitted, req.stop)
+                if was_stopped:
+                    finish_reason = "stop"
+                    break
+
+            await asyncio.sleep(decode_delay)
+            chunk = ChatCompletionChunk(
+                id=req_id,
+                created=created,
+                model=config.model_name,
+                choices=[
+                    StreamChoice(
+                        index=idx,
+                        delta=DeltaMessage(content=char),
+                        logprobs=None,
+                    )
+                ],
+                system_fingerprint=SYSTEM_FINGERPRINT,
+            )
+            yield f"data: {chunk.model_dump_json()}\n\n"
+
+        total_completion += len(emitted)
+
+        # Finish chunk
+        chunk = ChatCompletionChunk(
+            id=req_id,
+            created=created,
+            model=config.model_name,
+            choices=[
+                StreamChoice(
+                    index=idx,
+                    delta=DeltaMessage(),
+                    finish_reason=finish_reason,
+                    logprobs=None,
+                )
+            ],
+            system_fingerprint=SYSTEM_FINGERPRINT,
+        )
+        yield f"data: {chunk.model_dump_json()}\n\n"
+
+    # Usage chunk
+    if include_usage:
+        usage_chunk = ChatCompletionChunk(
+            id=req_id,
+            created=created,
+            model=config.model_name,
+            choices=[],
+            system_fingerprint=SYSTEM_FINGERPRINT,
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion,
+                total_tokens=prompt_tokens + total_completion,
+            ),
+        )
+        yield f"data: {usage_chunk.model_dump_json()}\n\n"
+
+    yield "data: [DONE]\n\n"
+
+
+async def _stream_completion(
+    config: ServerConfig,
+    req: CompletionRequest,
+    prompt_tokens: int,
+    max_tokens: int,
+    n: int,
+    ignore_eos: bool,
+):
+    """Stream completion chunks with per-token decode delay."""
+    req_id = generate_id("cmpl")
+    created = now_ts()
+    include_usage = req.stream_options.get("include_usage", False) if req.stream_options else False
+    decode_delay = _compute_decode_delay(config)
+    total_completion = 0
+
+    for idx in range(n):
+        num_tokens, finish_reason = _compute_output_length(
+            max_tokens, config.eos_min_ratio, ignore_eos
+        )
+        text = render_dummy_text(num_tokens)
+
+        emitted = ""
+        for char in text:
+            emitted += char
+            if req.stop:
+                _, was_stopped = _check_stop_sequences(emitted, req.stop)
+                if was_stopped:
+                    finish_reason = "stop"
+                    break
+
+            await asyncio.sleep(decode_delay)
+            chunk = CompletionChunk(
+                id=req_id,
+                created=created,
+                model=config.model_name,
+                choices=[
+                    CompletionStreamChoice(
+                        index=idx,
+                        text=char,
+                        logprobs=None,
+                    )
+                ],
+                system_fingerprint=SYSTEM_FINGERPRINT,
+            )
+            yield f"data: {chunk.model_dump_json()}\n\n"
+
+        total_completion += len(emitted)
+
+        # Finish chunk
+        chunk = CompletionChunk(
+            id=req_id,
+            created=created,
+            model=config.model_name,
+            choices=[
+                CompletionStreamChoice(
+                    index=idx,
+                    text="",
+                    finish_reason=finish_reason,
+                    logprobs=None,
+                )
+            ],
+            system_fingerprint=SYSTEM_FINGERPRINT,
+        )
+        yield f"data: {chunk.model_dump_json()}\n\n"
+
+    if include_usage:
+        usage_chunk = CompletionChunk(
+            id=req_id,
+            created=created,
+            model=config.model_name,
+            choices=[],
+            system_fingerprint=SYSTEM_FINGERPRINT,
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion,
+                total_tokens=prompt_tokens + total_completion,
+            ),
+        )
+        yield f"data: {usage_chunk.model_dump_json()}\n\n"
+
+    yield "data: [DONE]\n\n"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,586 @@
+"""Tests for M2: Unified server — TC1.x through TC6.x and TC5.x (EOS)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from xpyd_sim.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def dual_config():
+    return ServerConfig(
+        mode="dual",
+        model_name="test-model",
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+        eos_min_ratio=0.5,
+        max_model_len=4096,
+    )
+
+
+@pytest.fixture
+def prefill_config():
+    return ServerConfig(
+        mode="prefill",
+        model_name="test-prefill",
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+    )
+
+
+@pytest.fixture
+def decode_config():
+    return ServerConfig(
+        mode="decode",
+        model_name="test-decode",
+        prefill_delay_ms=50,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+    )
+
+
+@pytest.fixture
+def dual_client(dual_config):
+    app = create_app(dual_config)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture
+def prefill_client(prefill_config):
+    app = create_app(prefill_config)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture
+def decode_client(decode_config):
+    app = create_app(decode_config)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# === TC1: Mode Switching ===
+
+
+class TestModeSwitching:
+    """TC1.1-TC1.3: Mode switching."""
+
+    async def test_tc1_1_dual_mode(self, dual_client):
+        """TC1.1: Start dual mode — both prefill + decode have latency."""
+        r = await dual_client.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["mode"] == "dual"
+        assert data["status"] == "ok"
+
+    async def test_tc1_2_prefill_mode(self, prefill_client):
+        """TC1.2: Start prefill mode."""
+        r = await prefill_client.get("/health")
+        assert r.status_code == 200
+        assert r.json()["mode"] == "prefill"
+
+    async def test_tc1_3_decode_mode(self, decode_client):
+        """TC1.3: Start decode mode — prefill delay = 0."""
+        r = await decode_client.get("/health")
+        assert r.status_code == 200
+        assert r.json()["mode"] == "decode"
+
+
+# === TC2: Prefill Delay ===
+
+
+class TestPrefillDelay:
+    """TC2.1-TC2.2: Fixed prefill delay."""
+
+    async def test_tc2_1_short_prompt(self):
+        """TC2.1: Fixed delay, short prompt — low latency."""
+        config = ServerConfig(
+            prefill_delay_ms=10,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 1},
+            )
+            assert r.status_code == 200
+
+    async def test_tc2_2_decode_mode_no_prefill_delay(self):
+        """TC2.2: Decode mode has zero prefill delay."""
+        config = ServerConfig(
+            mode="decode",
+            prefill_delay_ms=500,  # high, but decode mode should skip it
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            import time
+
+            t0 = time.monotonic()
+            r = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 1},
+            )
+            elapsed = time.monotonic() - t0
+            assert r.status_code == 200
+            # Should be fast since decode mode skips prefill
+            assert elapsed < 0.3
+
+
+# === TC3: KV Transfer Delay ===
+
+
+class TestKVTransferDelay:
+    """TC3.1-TC3.3: KV transfer delay."""
+
+    async def test_tc3_1_dual_no_kv_delay(self):
+        """TC3.1: Dual mode — KV delay = 0 (local)."""
+        config = ServerConfig(
+            mode="dual",
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=100,  # set high, but dual should skip it
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            import time
+
+            t0 = time.monotonic()
+            r = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 1},
+            )
+            elapsed = time.monotonic() - t0
+            assert r.status_code == 200
+            assert elapsed < 0.05  # dual has 0 KV delay
+
+    async def test_tc3_2_prefill_no_kv_delay(self):
+        """TC3.2: Prefill mode — no KV wait."""
+        config = ServerConfig(
+            mode="prefill",
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=100,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            import time
+
+            t0 = time.monotonic()
+            r = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 1},
+            )
+            elapsed = time.monotonic() - t0
+            assert r.status_code == 200
+            assert elapsed < 0.05
+
+    async def test_tc3_3_kv_delay_zero(self):
+        """TC3.3: KV delay = 0 (async mode) — no additional latency."""
+        config = ServerConfig(
+            mode="decode",
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 1},
+            )
+            assert r.status_code == 200
+
+
+# === TC4: Decode Delay ===
+
+
+class TestDecodeDelay:
+    """TC4.1-TC4.2: Decode delay."""
+
+    async def test_tc4_1_stable_token_interval(self):
+        """TC4.1: Fixed delay — stable token interval."""
+        config = ServerConfig(
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 5,
+                    "ignore_eos": True,
+                },
+            )
+            assert r.status_code == 200
+            data = r.json()
+            assert data["usage"]["completion_tokens"] == 5
+
+
+# === TC5: EOS Simulation ===
+
+
+class TestEOSSimulation:
+    """TC5.1-TC5.6: EOS simulation."""
+
+    async def test_tc5_1_default_eos(self, dual_client):
+        """TC5.1: Default config — output length in [max_tokens*0.5, max_tokens]."""
+        lengths = []
+        for _ in range(20):
+            r = await dual_client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 100,
+                },
+            )
+            data = r.json()
+            lengths.append(data["usage"]["completion_tokens"])
+        # Should have some variation
+        assert min(lengths) >= 50  # eos_min_ratio=0.5
+        assert max(lengths) <= 100
+
+    async def test_tc5_2_eos_triggered(self, dual_client):
+        """TC5.2: EOS triggered — finish_reason = 'stop'."""
+        # With eos_min_ratio=0.5 and max_tokens=100, many will be "stop"
+        found_stop = False
+        for _ in range(20):
+            r = await dual_client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 100,
+                },
+            )
+            data = r.json()
+            if data["choices"][0]["finish_reason"] == "stop":
+                found_stop = True
+                break
+        assert found_stop
+
+    async def test_tc5_3_max_tokens_reached(self, dual_client):
+        """TC5.3: Max tokens reached — finish_reason = 'length' with ignore_eos."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 10,
+                "ignore_eos": True,
+            },
+        )
+        data = r.json()
+        assert data["choices"][0]["finish_reason"] == "length"
+
+    async def test_tc5_4_ignore_eos(self, dual_client):
+        """TC5.4: ignore_eos=true — always output max_tokens."""
+        for _ in range(5):
+            r = await dual_client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 50,
+                    "ignore_eos": True,
+                },
+            )
+            data = r.json()
+            assert data["usage"]["completion_tokens"] == 50
+            assert data["choices"][0]["finish_reason"] == "length"
+
+    async def test_tc5_5_custom_eos_min_ratio(self):
+        """TC5.5: Custom eos_min_ratio — respects configured ratio."""
+        config = ServerConfig(
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+            eos_min_ratio=0.9,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            lengths = []
+            for _ in range(20):
+                r = await client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [{"role": "user", "content": "test"}],
+                        "max_tokens": 100,
+                    },
+                )
+                data = r.json()
+                lengths.append(data["usage"]["completion_tokens"])
+            assert min(lengths) >= 90  # eos_min_ratio=0.9
+
+    async def test_tc5_6_streaming_eos(self, dual_client):
+        """TC5.6: Streaming + EOS — correct streaming behavior."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 20,
+                "stream": True,
+            },
+        )
+        assert r.status_code == 200
+        text = r.text
+        lines = [line for line in text.strip().split("\n") if line.startswith("data: ")]
+        # Last data line should be [DONE]
+        assert lines[-1] == "data: [DONE]"
+        # Second to last should have finish_reason
+        last_chunk = json.loads(lines[-2][6:])
+        assert last_chunk["choices"][0]["finish_reason"] in ("stop", "length")
+
+
+# === TC6: OpenAI API Compliance ===
+
+
+class TestOpenAICompliance:
+    """TC6.1-TC6.13: OpenAI API compliance."""
+
+    async def test_tc6_1_completions_non_streaming(self, dual_client):
+        """TC6.1: /v1/completions non-streaming — correct response format."""
+        r = await dual_client.post(
+            "/v1/completions",
+            json={"prompt": "Hello", "max_tokens": 5, "ignore_eos": True},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "text_completion"
+        assert "id" in data
+        assert "choices" in data
+        assert "usage" in data
+        assert data["choices"][0]["text"]
+        assert data["system_fingerprint"] is not None
+
+    async def test_tc6_2_completions_streaming(self, dual_client):
+        """TC6.2: /v1/completions streaming — correct SSE format."""
+        r = await dual_client.post(
+            "/v1/completions",
+            json={"prompt": "Hello", "max_tokens": 5, "stream": True, "ignore_eos": True},
+        )
+        assert r.status_code == 200
+        lines = [line for line in r.text.strip().split("\n") if line.startswith("data: ")]
+        assert lines[-1] == "data: [DONE]"
+        chunk = json.loads(lines[0][6:])
+        assert chunk["object"] == "text_completion"
+
+    async def test_tc6_3_chat_non_streaming(self, dual_client):
+        """TC6.3: /v1/chat/completions non-streaming — correct format."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "ignore_eos": True,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "chat.completion"
+        assert data["choices"][0]["message"]["role"] == "assistant"
+        assert data["system_fingerprint"] is not None
+
+    async def test_tc6_4_chat_streaming_role(self, dual_client):
+        """TC6.4: /v1/chat/completions streaming — first chunk has role."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "stream": True,
+                "ignore_eos": True,
+            },
+        )
+        lines = [
+            line for line in r.text.strip().split("\n")
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        first = json.loads(lines[0][6:])
+        assert first["choices"][0]["delta"]["role"] == "assistant"
+
+    async def test_tc6_5_models(self, dual_client):
+        """TC6.5: /v1/models — correct list format."""
+        r = await dual_client.get("/v1/models")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["id"] == "test-model"
+
+    async def test_tc6_6_all_sampling_params(self, dual_client):
+        """TC6.6: All sampling params accepted without error."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 1,
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "presence_penalty": 0.5,
+                "frequency_penalty": 0.5,
+                "seed": 42,
+                "n": 1,
+                "stop": ["end"],
+                "user": "test-user",
+            },
+        )
+        assert r.status_code == 200
+
+    async def test_tc6_7_n_greater_than_1(self, dual_client):
+        """TC6.7: n > 1 — multiple choices returned."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "n": 3,
+                "ignore_eos": True,
+            },
+        )
+        data = r.json()
+        assert len(data["choices"]) == 3
+        for i, c in enumerate(data["choices"]):
+            assert c["index"] == i
+
+    async def test_tc6_8_system_fingerprint(self, dual_client):
+        """TC6.8: seed parameter — system_fingerprint present."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 1,
+                "seed": 123,
+            },
+        )
+        data = r.json()
+        assert data["system_fingerprint"] is not None
+
+    async def test_tc6_9_stream_options_include_usage(self, dual_client):
+        """TC6.9: stream_options.include_usage — usage in final chunk."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 3,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+                "ignore_eos": True,
+            },
+        )
+        lines = [
+            line for line in r.text.strip().split("\n")
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        last = json.loads(lines[-1][6:])
+        assert last["usage"] is not None
+        assert last["usage"]["prompt_tokens"] > 0
+
+    async def test_tc6_10_logprobs_field(self, dual_client):
+        """TC6.10: logprobs field present (null) in choices."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 1,
+            },
+        )
+        data = r.json()
+        assert "logprobs" in data["choices"][0]
+
+    async def test_tc6_11_prompt_formats(self, dual_client):
+        """TC6.11: 4 prompt formats — all supported."""
+        # String prompt
+        r = await dual_client.post(
+            "/v1/completions", json={"prompt": "Hello", "max_tokens": 1}
+        )
+        assert r.status_code == 200
+
+        # List of strings
+        r = await dual_client.post(
+            "/v1/completions", json={"prompt": ["Hello", "World"], "max_tokens": 1}
+        )
+        assert r.status_code == 200
+
+        # Token IDs
+        r = await dual_client.post(
+            "/v1/completions", json={"prompt": [1, 2, 3], "max_tokens": 1}
+        )
+        assert r.status_code == 200
+
+        # Chat messages
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 1},
+        )
+        assert r.status_code == 200
+
+    async def test_tc6_12_invalid_json(self, dual_client):
+        """TC6.12: Invalid JSON body — 400 error."""
+        r = await dual_client.post(
+            "/v1/chat/completions",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
+        assert r.status_code == 400
+
+    async def test_tc6_13_missing_required_fields(self, dual_client):
+        """TC6.13: Missing required fields — appropriate error."""
+        r = await dual_client.post("/v1/chat/completions", json={})
+        assert r.status_code == 400
+
+
+# === Ping endpoint ===
+
+
+class TestPing:
+    """TC11.1-TC11.2: Ping endpoint."""
+
+    async def test_tc11_1_get_ping(self, dual_client):
+        """TC11.1: GET /ping → pong."""
+        r = await dual_client.get("/ping")
+        assert r.status_code == 200
+        assert r.text == "pong"
+
+    async def test_tc11_2_post_ping(self, dual_client):
+        """TC11.2: POST /ping → pong."""
+        r = await dual_client.post("/ping")
+        assert r.status_code == 200
+        assert r.text == "pong"
+
+
+# === Model card max_model_len ===
+
+
+class TestModelCard:
+    """TC11.3: Model card with max_model_len."""
+
+    async def test_tc11_3_max_model_len(self, dual_client):
+        """TC11.3: /v1/models includes max_model_len."""
+        r = await dual_client.get("/v1/models")
+        data = r.json()
+        assert data["data"][0]["max_model_len"] == 4096


### PR DESCRIPTION
## Summary

Implements Milestone 2: Core Server — Unified Engine.

### Changes
- New `server.py`: single FastAPI app with `dual`/`prefill`/`decode` modes
- Three latency parameters: `prefill_delay_ms`, `kv_transfer_delay_ms`, `decode_delay_per_token_ms`
- Mode-based latency behavior per DESIGN.md (decode skips prefill, dual skips KV transfer)
- EOS simulation: random output length in `[max_tokens * eos_min_ratio, max_tokens]`, `ignore_eos` support
- `/ping` endpoint (GET + POST → `pong`)
- `/health` returns mode + config
- `/v1/models` includes `max_model_len`
- Parameter type validation (HTTP 400 on wrong types)
- Missing required fields validation
- Stop sequence truncation (streaming + non-streaming)
- Updated CLI with unified command
- 32 new tests in `test_server.py` covering TC1.x–TC6.x, TC11.1–TC11.4

### Test Cases Covered
TC1.1–TC1.3, TC2.1–TC2.2, TC3.1, TC3.3, TC4.1, TC5.1–TC5.6, TC6.1–TC6.13, TC11.1–TC11.4

All 59 tests pass. Lint clean (ruff + isort).

Closes #3