### PR TITLE
feat: M4 — CLI + YAML Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "uvicorn>=0.30.0",
     "pydantic>=2.0.0",
     "httpx>=0.27.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/xpyd_sim/cli.py
+++ b/src/xpyd_sim/cli.py
@@ -1,8 +1,166 @@
-"""CLI entry point."""
+"""CLI entry point with YAML config and environment variable support."""
 
 from __future__ import annotations
 
 import argparse
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_yaml_config(path: str | Path) -> dict[str, Any]:
+    """Load and flatten a YAML config file into CLI-compatible keys."""
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    flat: dict[str, Any] = {}
+    # Top-level keys
+    for key in ("mode", "port", "host", "model", "max_model_len"):
+        if key in raw:
+            flat[key] = raw[key]
+
+    # Nested latency section
+    latency = raw.get("latency", {})
+    for key in ("prefill_delay_ms", "kv_transfer_delay_ms", "decode_delay_per_token_ms"):
+        if key in latency:
+            flat[key] = latency[key]
+
+    # Nested eos section
+    eos = raw.get("eos", {})
+    if "min_ratio" in eos:
+        flat["eos_min_ratio"] = eos["min_ratio"]
+
+    # Nested warmup section
+    warmup = raw.get("warmup", {})
+    if "requests" in warmup:
+        flat["warmup_requests"] = warmup["requests"]
+    if "penalty_ms" in warmup:
+        flat["warmup_penalty_ms"] = warmup["penalty_ms"]
+
+    # Nested logging section
+    logging_cfg = raw.get("logging", {})
+    if "request_log" in logging_cfg:
+        flat["log_requests"] = logging_cfg["request_log"]
+
+    # Profile
+    if "profile" in raw:
+        flat["profile"] = raw["profile"]
+
+    return flat
+
+
+# Mapping: config key -> (env var name, type converter)
+_ENV_MAP: dict[str, tuple[str, type]] = {
+    "mode": ("XPYD_SIM_MODE", str),
+    "port": ("XPYD_SIM_PORT", int),
+    "host": ("XPYD_SIM_HOST", str),
+    "model": ("XPYD_SIM_MODEL", str),
+    "prefill_delay_ms": ("XPYD_SIM_PREFILL_DELAY_MS", float),
+    "kv_transfer_delay_ms": ("XPYD_SIM_KV_TRANSFER_DELAY_MS", float),
+    "decode_delay_per_token_ms": ("XPYD_SIM_DECODE_DELAY_PER_TOKEN_MS", float),
+    "eos_min_ratio": ("XPYD_SIM_EOS_MIN_RATIO", float),
+    "max_model_len": ("XPYD_SIM_MAX_MODEL_LEN", int),
+    "warmup_requests": ("XPYD_SIM_WARMUP_REQUESTS", int),
+    "warmup_penalty_ms": ("XPYD_SIM_WARMUP_PENALTY_MS", float),
+    "log_requests": ("XPYD_SIM_LOG_REQUESTS", str),
+    "profile": ("XPYD_SIM_PROFILE", str),
+}
+
+# Default values for all config keys
+_DEFAULTS: dict[str, Any] = {
+    "mode": "dual",
+    "port": 8000,
+    "host": "0.0.0.0",
+    "model": "dummy",
+    "prefill_delay_ms": 50.0,
+    "kv_transfer_delay_ms": 5.0,
+    "decode_delay_per_token_ms": 10.0,
+    "eos_min_ratio": 0.5,
+    "max_model_len": 131072,
+    "warmup_requests": 0,
+    "warmup_penalty_ms": 0.0,
+    "log_requests": None,
+    "profile": None,
+}
+
+
+def _resolve_config(
+    cli_args: argparse.Namespace,
+    yaml_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve config with priority: CLI > env vars > YAML > defaults."""
+    result: dict[str, Any] = {}
+
+    # Map CLI arg names to config keys
+    cli_to_key = {
+        "mode": "mode",
+        "port": "port",
+        "host": "host",
+        "model": "model",
+        "prefill_delay_ms": "prefill_delay_ms",
+        "kv_transfer_delay_ms": "kv_transfer_delay_ms",
+        "decode_delay_per_token_ms": "decode_delay_per_token_ms",
+        "eos_min_ratio": "eos_min_ratio",
+        "max_model_len": "max_model_len",
+        "warmup_requests": "warmup_requests",
+        "warmup_penalty_ms": "warmup_penalty_ms",
+        "log_requests": "log_requests",
+        "profile": "profile",
+    }
+
+    for cli_attr, key in cli_to_key.items():
+        # 1. Check if CLI arg was explicitly provided
+        cli_val = getattr(cli_args, cli_attr, None)
+        default_val = _DEFAULTS[key]
+        # argparse sets unset args to their default — we use None defaults
+        # and check _explicitly_set to detect user intent
+        explicitly_set = key in getattr(cli_args, "_explicitly_set", set())
+
+        if explicitly_set:
+            result[key] = cli_val
+            continue
+
+        # 2. Check environment variable
+        env_name, converter = _ENV_MAP[key]
+        env_val = os.environ.get(env_name)
+        if env_val is not None:
+            try:
+                result[key] = converter(env_val)
+            except (ValueError, TypeError):
+                result[key] = default_val
+            continue
+
+        # 3. Check YAML config
+        if yaml_config and key in yaml_config:
+            result[key] = yaml_config[key]
+            continue
+
+        # 4. Use default
+        result[key] = default_val
+
+    return result
+
+
+class _TrackingNamespace(argparse.Namespace):
+    """Namespace that tracks which arguments were explicitly set on CLI."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._explicitly_set: set[str] = set()
+
+
+class _TrackAction(argparse.Action):
+    """Custom action that records when an arg is explicitly provided."""
+
+    def __call__(  # type: ignore[override]
+        self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
+        values: Any, option_string: str | None = None,
+    ) -> None:
+        setattr(namespace, self.dest, values)
+        if hasattr(namespace, "_explicitly_set"):
+            namespace._explicitly_set.add(self.dest)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -10,17 +168,25 @@ def main(argv: list[str] | None = None) -> None:
     sub = parser.add_subparsers(dest="command")
 
     serve = sub.add_parser("serve", help="Start the unified simulator server")
-    serve.add_argument("--mode", choices=["dual", "prefill", "decode"], default="dual")
-    serve.add_argument("--port", type=int, default=8000)
-    serve.add_argument("--host", default="0.0.0.0")
-    serve.add_argument("--model", default="dummy")
-    serve.add_argument("--prefill-delay-ms", type=float, default=50.0)
-    serve.add_argument("--kv-transfer-delay-ms", type=float, default=5.0)
-    serve.add_argument("--decode-delay-per-token-ms", type=float, default=10.0)
-    serve.add_argument("--eos-min-ratio", type=float, default=0.5)
-    serve.add_argument("--max-model-len", type=int, default=131072)
+    serve.add_argument("--mode", choices=["dual", "prefill", "decode"], default="dual",
+                       action=_TrackAction)
+    serve.add_argument("--port", type=int, default=8000, action=_TrackAction)
+    serve.add_argument("--host", default="0.0.0.0", action=_TrackAction)
+    serve.add_argument("--model", default="dummy", action=_TrackAction)
+    serve.add_argument("--prefill-delay-ms", type=float, default=50.0, action=_TrackAction)
+    serve.add_argument("--kv-transfer-delay-ms", type=float, default=5.0, action=_TrackAction)
+    serve.add_argument("--decode-delay-per-token-ms", type=float, default=10.0,
+                       action=_TrackAction)
+    serve.add_argument("--eos-min-ratio", type=float, default=0.5, action=_TrackAction)
+    serve.add_argument("--max-model-len", type=int, default=131072, action=_TrackAction)
+    serve.add_argument("--warmup-requests", type=int, default=0, action=_TrackAction)
+    serve.add_argument("--warmup-penalty-ms", type=float, default=0.0, action=_TrackAction)
+    serve.add_argument("--log-requests", type=str, default=None, action=_TrackAction)
+    serve.add_argument("--profile", type=str, default=None, action=_TrackAction)
+    serve.add_argument("--config", type=str, default=None, help="YAML config file path",
+                       action=_TrackAction)
 
-    args = parser.parse_args(argv)
+    args = parser.parse_args(argv, namespace=_TrackingNamespace())
     if not args.command:
         parser.print_help()
         return
@@ -30,14 +196,25 @@ def main(argv: list[str] | None = None) -> None:
 
         from xpyd_sim.server import ServerConfig, create_app
 
+        # Load YAML config if provided
+        yaml_config = None
+        if args.config:
+            yaml_config = _load_yaml_config(args.config)
+
+        cfg = _resolve_config(args, yaml_config)
+
         config = ServerConfig(
-            mode=args.mode,
-            model_name=args.model,
-            prefill_delay_ms=args.prefill_delay_ms,
-            kv_transfer_delay_ms=args.kv_transfer_delay_ms,
-            decode_delay_per_token_ms=args.decode_delay_per_token_ms,
-            eos_min_ratio=args.eos_min_ratio,
-            max_model_len=args.max_model_len,
+            mode=cfg["mode"],
+            model_name=cfg["model"],
+            prefill_delay_ms=cfg["prefill_delay_ms"],
+            kv_transfer_delay_ms=cfg["kv_transfer_delay_ms"],
+            decode_delay_per_token_ms=cfg["decode_delay_per_token_ms"],
+            eos_min_ratio=cfg["eos_min_ratio"],
+            max_model_len=cfg["max_model_len"],
+            warmup_requests=cfg["warmup_requests"],
+            warmup_penalty_ms=cfg["warmup_penalty_ms"],
+            log_requests=cfg["log_requests"],
+            profile=cfg["profile"],
         )
         app = create_app(config)
-        uvicorn.run(app, host=args.host, port=args.port)
+        uvicorn.run(app, host=cfg["host"], port=cfg["port"])

--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -56,6 +56,10 @@ class ServerConfig:
     eos_min_ratio: float = 0.5
     max_model_len: int = 131072
     default_max_tokens: int = 16
+    warmup_requests: int = 0
+    warmup_penalty_ms: float = 0.0
+    log_requests: str | None = None
+    profile: str | None = None
 
 
 def _compute_output_length(

--- a/tests/test_m4_config.py
+++ b/tests/test_m4_config.py
@@ -1,0 +1,268 @@
+"""Tests for M4: CLI + YAML Configuration (TC11.9, TC11.10, TC11.11)."""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_sim.cli import _load_yaml_config, _resolve_config, _TrackingNamespace
+
+
+@pytest.fixture()
+def yaml_config_file(tmp_path: Path) -> Path:
+    """Create a sample YAML config file."""
+    config = textwrap.dedent("""\
+        mode: prefill
+        port: 9090
+        host: 127.0.0.1
+        model: test-model
+        max_model_len: 65536
+
+        latency:
+          prefill_delay_ms: 100.0
+          kv_transfer_delay_ms: 10.0
+          decode_delay_per_token_ms: 20.0
+
+        eos:
+          min_ratio: 0.3
+
+        warmup:
+          requests: 5
+          penalty_ms: 300.0
+
+        logging:
+          request_log: /tmp/test-requests.jsonl
+
+        profile: /tmp/test-profile.yaml
+    """)
+    p = tmp_path / "config.yaml"
+    p.write_text(config)
+    return p
+
+
+class TestYAMLLoading:
+    """Test YAML config file parsing."""
+
+    def test_load_yaml_config(self, yaml_config_file: Path) -> None:
+        cfg = _load_yaml_config(yaml_config_file)
+        assert cfg["mode"] == "prefill"
+        assert cfg["port"] == 9090
+        assert cfg["host"] == "127.0.0.1"
+        assert cfg["model"] == "test-model"
+        assert cfg["max_model_len"] == 65536
+        assert cfg["prefill_delay_ms"] == 100.0
+        assert cfg["kv_transfer_delay_ms"] == 10.0
+        assert cfg["decode_delay_per_token_ms"] == 20.0
+        assert cfg["eos_min_ratio"] == 0.3
+        assert cfg["warmup_requests"] == 5
+        assert cfg["warmup_penalty_ms"] == 300.0
+        assert cfg["log_requests"] == "/tmp/test-requests.jsonl"
+        assert cfg["profile"] == "/tmp/test-profile.yaml"
+
+    def test_load_empty_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.yaml"
+        p.write_text("")
+        cfg = _load_yaml_config(p)
+        assert cfg == {}
+
+    def test_load_partial_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "partial.yaml"
+        p.write_text("mode: decode\nport: 3000\n")
+        cfg = _load_yaml_config(p)
+        assert cfg["mode"] == "decode"
+        assert cfg["port"] == 3000
+        assert "prefill_delay_ms" not in cfg
+
+
+class TestTC11_9_CLIOverridesYAML:
+    """TC11.9: CLI args override YAML config."""
+
+    def test_cli_overrides_yaml_mode(self, yaml_config_file: Path) -> None:
+        """CLI --mode should override YAML mode."""
+        yaml_cfg = _load_yaml_config(yaml_config_file)
+        ns = _TrackingNamespace()
+        ns.mode = "decode"
+        ns._explicitly_set = {"mode"}
+        # Set other attrs with defaults (not explicitly set)
+        for attr in (
+            "port", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        result = _resolve_config(ns, yaml_cfg)
+        assert result["mode"] == "decode"  # CLI wins
+        assert result["port"] == 9090  # YAML fills in
+
+    def test_cli_overrides_yaml_port(self, yaml_config_file: Path) -> None:
+        yaml_cfg = _load_yaml_config(yaml_config_file)
+        ns = _TrackingNamespace()
+        ns.port = 7777
+        ns._explicitly_set = {"port"}
+        for attr in (
+            "mode", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        result = _resolve_config(ns, yaml_cfg)
+        assert result["port"] == 7777  # CLI wins
+        assert result["mode"] == "prefill"  # YAML fills in
+
+    def test_cli_overrides_yaml_latency(self, yaml_config_file: Path) -> None:
+        yaml_cfg = _load_yaml_config(yaml_config_file)
+        ns = _TrackingNamespace()
+        ns.prefill_delay_ms = 999.0
+        ns._explicitly_set = {"prefill_delay_ms"}
+        for attr in (
+            "mode", "port", "host", "model",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        result = _resolve_config(ns, yaml_cfg)
+        assert result["prefill_delay_ms"] == 999.0  # CLI wins
+        assert result["kv_transfer_delay_ms"] == 10.0  # YAML fills in
+
+
+class TestTC11_10_YAMLOnlyConfig:
+    """TC11.10: YAML-only config — all settings applied from YAML."""
+
+    def test_yaml_only_all_settings(self, yaml_config_file: Path) -> None:
+        """When no CLI args are explicitly set, all values come from YAML."""
+        yaml_cfg = _load_yaml_config(yaml_config_file)
+        ns = _TrackingNamespace()
+        # Nothing explicitly set
+        for attr in (
+            "mode", "port", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        result = _resolve_config(ns, yaml_cfg)
+        assert result["mode"] == "prefill"
+        assert result["port"] == 9090
+        assert result["host"] == "127.0.0.1"
+        assert result["model"] == "test-model"
+        assert result["max_model_len"] == 65536
+        assert result["prefill_delay_ms"] == 100.0
+        assert result["kv_transfer_delay_ms"] == 10.0
+        assert result["decode_delay_per_token_ms"] == 20.0
+        assert result["eos_min_ratio"] == 0.3
+        assert result["warmup_requests"] == 5
+        assert result["warmup_penalty_ms"] == 300.0
+        assert result["log_requests"] == "/tmp/test-requests.jsonl"
+        assert result["profile"] == "/tmp/test-profile.yaml"
+
+
+class TestTC11_11_DefaultConfig:
+    """TC11.11: No config (all defaults) — server starts with sensible defaults."""
+
+    def test_all_defaults(self) -> None:
+        """When nothing is provided, sensible defaults are used."""
+        ns = _TrackingNamespace()
+        for attr in (
+            "mode", "port", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        result = _resolve_config(ns, yaml_config=None)
+        assert result["mode"] == "dual"
+        assert result["port"] == 8000
+        assert result["host"] == "0.0.0.0"
+        assert result["model"] == "dummy"
+        assert result["prefill_delay_ms"] == 50.0
+        assert result["kv_transfer_delay_ms"] == 5.0
+        assert result["decode_delay_per_token_ms"] == 10.0
+        assert result["eos_min_ratio"] == 0.5
+        assert result["max_model_len"] == 131072
+        assert result["warmup_requests"] == 0
+        assert result["warmup_penalty_ms"] == 0.0
+        assert result["log_requests"] is None
+        assert result["profile"] is None
+
+
+class TestEnvVarFallback:
+    """Test environment variable fallback (priority: CLI > env > YAML > defaults)."""
+
+    def test_env_var_overrides_yaml(self, yaml_config_file: Path) -> None:
+        yaml_cfg = _load_yaml_config(yaml_config_file)
+        ns = _TrackingNamespace()
+        for attr in (
+            "mode", "port", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        with patch.dict(os.environ, {"XPYD_SIM_PORT": "5555"}):
+            result = _resolve_config(ns, yaml_cfg)
+        assert result["port"] == 5555  # env wins over YAML
+        assert result["mode"] == "prefill"  # YAML still used for others
+
+    def test_cli_overrides_env(self) -> None:
+        ns = _TrackingNamespace()
+        ns.port = 1234
+        ns._explicitly_set = {"port"}
+        for attr in (
+            "mode", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        with patch.dict(os.environ, {"XPYD_SIM_PORT": "5555"}):
+            result = _resolve_config(ns)
+        assert result["port"] == 1234  # CLI wins over env
+
+    def test_env_overrides_default(self) -> None:
+        ns = _TrackingNamespace()
+        for attr in (
+            "mode", "port", "host", "model", "prefill_delay_ms",
+            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
+            "eos_min_ratio", "max_model_len", "warmup_requests",
+            "warmup_penalty_ms", "log_requests", "profile",
+        ):
+            setattr(ns, attr, None)
+
+        with patch.dict(os.environ, {"XPYD_SIM_MODE": "decode"}):
+            result = _resolve_config(ns)
+        assert result["mode"] == "decode"
+
+
+class TestCLIParsing:
+    """Test that CLI argument parsing correctly tracks explicitly-set args."""
+
+    def test_parse_with_explicit_args(self) -> None:
+        """Verify the full parse path tracks explicitly set args."""
+        # We test the argparse integration indirectly through main()
+        # by verifying the serve subcommand parses correctly
+        import argparse
+
+        from xpyd_sim.cli import _TrackAction, _TrackingNamespace
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--mode", default="dual", action=_TrackAction)
+        parser.add_argument("--port", type=int, default=8000, action=_TrackAction)
+
+        ns = parser.parse_args(["--mode", "prefill"], namespace=_TrackingNamespace())
+        assert ns.mode == "prefill"
+        assert "mode" in ns._explicitly_set
+        assert "port" not in ns._explicitly_set


### PR DESCRIPTION
## Summary

Implement Milestone 4: CLI + YAML Configuration support.

### Changes
- **YAML config file**: `--config config.yaml` loads settings from a YAML file with nested structure (latency, eos, warmup, logging sections)
- **CLI overrides YAML**: Explicit CLI args always take precedence over YAML values
- **Environment variable fallback**: All settings can be set via `XPYD_SIM_*` env vars (priority: CLI > env > YAML > defaults)
- **New CLI args**: `--warmup-requests`, `--warmup-penalty-ms`, `--log-requests`, `--profile`, `--config`
- **ServerConfig expanded**: Added `warmup_requests`, `warmup_penalty_ms`, `log_requests`, `profile` fields
- **pyyaml** added as dependency

### Test Cases
- **TC11.9** ✅ CLI args override YAML config
- **TC11.10** ✅ YAML-only config — all settings applied from YAML
- **TC11.11** ✅ No config (all defaults) — server starts with sensible defaults
- Plus: env var fallback tests, YAML parsing tests, CLI tracking tests

### All 83 tests pass, lint clean.

Closes #7