### PR TITLE
feat: M6 Observability — /metrics, JSONL logging, warm-up simulation

### DIFF
--- a/src/xpyd_sim/observability.py
+++ b/src/xpyd_sim/observability.py
@@ -1,0 +1,123 @@
+"""Observability: Prometheus metrics, JSONL request logging, warm-up tracking."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class Metrics:
+    """Thread-safe Prometheus-style metrics collector."""
+
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    requests_total: int = 0
+    tokens_generated_total: int = 0
+    active_requests: int = 0
+    # Histogram buckets for request duration (seconds)
+    _durations: list[float] = field(default_factory=list, repr=False)
+
+    _BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
+
+    def inc_requests(self) -> None:
+        with self._lock:
+            self.requests_total += 1
+
+    def inc_tokens(self, n: int) -> None:
+        with self._lock:
+            self.tokens_generated_total += n
+
+    def inc_active(self) -> None:
+        with self._lock:
+            self.active_requests += 1
+
+    def dec_active(self) -> None:
+        with self._lock:
+            self.active_requests = max(0, self.active_requests - 1)
+
+    def observe_duration(self, seconds: float) -> None:
+        with self._lock:
+            self._durations.append(seconds)
+
+    def render_prometheus(self) -> str:
+        with self._lock:
+            lines: list[str] = []
+
+            lines.append("# HELP xpyd_sim_requests_total Total requests received.")
+            lines.append("# TYPE xpyd_sim_requests_total counter")
+            lines.append(f"xpyd_sim_requests_total {self.requests_total}")
+
+            lines.append("# HELP xpyd_sim_tokens_generated_total Total tokens generated.")
+            lines.append("# TYPE xpyd_sim_tokens_generated_total counter")
+            lines.append(f"xpyd_sim_tokens_generated_total {self.tokens_generated_total}")
+
+            lines.append("# HELP xpyd_sim_active_requests Current concurrent requests.")
+            lines.append("# TYPE xpyd_sim_active_requests gauge")
+            lines.append(f"xpyd_sim_active_requests {self.active_requests}")
+
+            lines.append(
+                "# HELP xpyd_sim_request_duration_seconds Request latency histogram."
+            )
+            lines.append("# TYPE xpyd_sim_request_duration_seconds histogram")
+            durations = list(self._durations)
+            count = len(durations)
+            total = sum(durations) if durations else 0.0
+            for b in self._BUCKETS:
+                bucket_count = sum(1 for d in durations if d <= b)
+                lines.append(
+                    f'xpyd_sim_request_duration_seconds_bucket{{le="{b}"}} {bucket_count}'
+                )
+            lines.append(
+                f'xpyd_sim_request_duration_seconds_bucket{{le="+Inf"}} {count}'
+            )
+            lines.append(f"xpyd_sim_request_duration_seconds_sum {total:.6f}")
+            lines.append(f"xpyd_sim_request_duration_seconds_count {count}")
+
+            return "\n".join(lines) + "\n"
+
+
+class RequestLogger:
+    """Append-only JSONL request logger."""
+
+    def __init__(self, path: str | Path | None) -> None:
+        self._path = Path(path) if path else None
+        self._lock = threading.Lock()
+
+    def log(self, record: dict[str, Any]) -> None:
+        if self._path is None:
+            return
+        line = json.dumps(record, separators=(",", ":"))
+        with self._lock:
+            with open(self._path, "a") as f:
+                f.write(line + "\n")
+
+
+class WarmupTracker:
+    """Track warm-up state and apply penalty."""
+
+    def __init__(self, warmup_requests: int, warmup_penalty_ms: float) -> None:
+        self._total = warmup_requests
+        self._penalty_s = warmup_penalty_ms / 1000.0
+        self._count = 0
+        self._lock = threading.Lock()
+
+    def get_penalty(self) -> float:
+        """Return penalty in seconds if still warming up, else 0."""
+        with self._lock:
+            if self._count < self._total:
+                self._count += 1
+                return self._penalty_s
+            return 0.0
+
+    @property
+    def is_warm(self) -> bool:
+        with self._lock:
+            return self._count >= self._total
+
+    @property
+    def requests_served(self) -> int:
+        with self._lock:
+            return self._count

--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import math
 import random
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
@@ -40,6 +41,7 @@ from xpyd_sim.common.models import (
     StreamChoice,
     UsageInfo,
 )
+from xpyd_sim.observability import Metrics, RequestLogger, WarmupTracker
 from xpyd_sim.profile import LatencyProfile
 
 SYSTEM_FINGERPRINT = "fp_xpyd_sim"
@@ -62,11 +64,20 @@ class ServerConfig:
     log_requests: str | None = None
     profile: str | None = None
     _latency_profile: LatencyProfile | None = None
+    _metrics: Metrics = field(default_factory=Metrics)
+    _request_logger: RequestLogger | None = None
+    _warmup_tracker: WarmupTracker | None = None
 
     def load_profile(self) -> None:
         """Load latency profile if configured."""
         if self.profile:
             self._latency_profile = LatencyProfile(self.profile)
+
+    def init_observability(self) -> None:
+        """Initialize metrics, request logger, and warmup tracker."""
+        self._metrics = Metrics()
+        self._request_logger = RequestLogger(self.log_requests)
+        self._warmup_tracker = WarmupTracker(self.warmup_requests, self.warmup_penalty_ms)
 
 
 def _compute_output_length(
@@ -135,11 +146,36 @@ def _compute_decode_delay(
     return config.decode_delay_per_token_ms / 1000.0
 
 
+def _log_request(
+    config: ServerConfig,
+    prompt_tokens: int,
+    output_tokens: int,
+    prefill_ms: float,
+    kv_transfer_ms: float,
+    decode_ms: float,
+    total_ms: float,
+) -> None:
+    """Log a request to JSONL if logger is configured."""
+    if config._request_logger is None:
+        return
+    config._request_logger.log({
+        "timestamp": int(time.time()),
+        "prompt_tokens": prompt_tokens,
+        "output_tokens": output_tokens,
+        "prefill_ms": round(prefill_ms, 2),
+        "kv_transfer_ms": round(kv_transfer_ms, 2),
+        "decode_ms": round(decode_ms, 2),
+        "total_ms": round(total_ms, 2),
+        "mode": config.mode,
+    })
+
+
 def create_app(config: ServerConfig | None = None) -> FastAPI:
     """Create the unified xPyD-sim FastAPI application."""
     if config is None:
         config = ServerConfig()
     config.load_profile()
+    config.init_observability()
 
     app = FastAPI(title="xPyD-sim")
     app.state.config = config
@@ -169,6 +205,13 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
             },
         }
 
+    @app.get("/metrics")
+    async def metrics():
+        return PlainTextResponse(
+            config._metrics.render_prometheus(),
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
+
     @app.get("/v1/models")
     async def list_models():
         card = ModelCard(
@@ -180,170 +223,234 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
 
     @app.post("/v1/chat/completions")
     async def chat_completions(request: Request):
+        request_start = time.monotonic()
+        config._metrics.inc_requests()
+        config._metrics.inc_active()
         try:
-            body = await request.json()
-        except Exception:
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "error": {"message": "Invalid JSON body", "type": "invalid_request_error"}
-                },
-            )
-        if "messages" not in body:
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "error": {
-                        "message": "Missing required field: messages",
-                        "type": "invalid_request_error",
-                    }
-                },
-            )
-
-        try:
-            req = ChatCompletionRequest(**body)
-        except ValidationError as e:
-            return JSONResponse(
-                status_code=400,
-                content={"error": {"message": str(e), "type": "invalid_request_error"}},
-            )
-
-        prompt_tokens = count_prompt_tokens(messages=req.messages)
-        max_tokens = get_effective_max_tokens(req.max_completion_tokens, req.max_tokens)
-        n = req.n or 1
-        ignore_eos = req.ignore_eos or False
-
-        # Simulate prefill + KV transfer
-        prefill_delay = _compute_prefill_delay(config, prompt_tokens)
-        kv_delay = _compute_kv_delay(config, prompt_tokens)
-        await asyncio.sleep(prefill_delay + kv_delay)
-
-        if req.stream:
-            return StreamingResponse(
-                _stream_chat(config, req, prompt_tokens, max_tokens, n, ignore_eos),
-                media_type="text/event-stream",
-            )
-
-        # Non-streaming
-        choices = []
-        total_completion = 0
-        for i in range(n):
-            num_tokens, finish_reason = _compute_output_length(
-                max_tokens, config.eos_min_ratio, ignore_eos
-            )
-            text = render_dummy_text(num_tokens)
-            text, stopped = _check_stop_sequences(text, req.stop)
-            if stopped:
-                finish_reason = "stop"
-                num_tokens = max(1, len(text) // 4)
-            total_completion += num_tokens
-            lp_data = None
-            if req.logprobs:
-                top_n = req.top_logprobs or 5
-                lp_data = generate_chat_logprobs(tokenize_text(text), top_n)
-            choices.append(
-                Choice(
-                    index=i,
-                    message=ChoiceMessage(role="assistant", content=text),
-                    finish_reason=finish_reason,
-                    logprobs=lp_data,
+            try:
+                body = await request.json()
+            except Exception:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": {
+                            "message": "Invalid JSON body",
+                            "type": "invalid_request_error",
+                        }
+                    },
                 )
+            if "messages" not in body:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": {
+                            "message": "Missing required field: messages",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                )
+
+            try:
+                req = ChatCompletionRequest(**body)
+            except ValidationError as e:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": {"message": str(e), "type": "invalid_request_error"}},
+                )
+
+            prompt_tokens = count_prompt_tokens(messages=req.messages)
+            max_tokens = get_effective_max_tokens(req.max_completion_tokens, req.max_tokens)
+            n = req.n or 1
+            ignore_eos = req.ignore_eos or False
+
+            # Warm-up penalty
+            warmup_penalty = config._warmup_tracker.get_penalty() if config._warmup_tracker else 0
+            if warmup_penalty > 0:
+                await asyncio.sleep(warmup_penalty)
+
+            # Simulate prefill + KV transfer
+            prefill_delay = _compute_prefill_delay(config, prompt_tokens)
+            kv_delay = _compute_kv_delay(config, prompt_tokens)
+            await asyncio.sleep(prefill_delay + kv_delay)
+
+            if req.stream:
+                return StreamingResponse(
+                    _stream_chat(config, req, prompt_tokens, max_tokens, n, ignore_eos),
+                    media_type="text/event-stream",
+                )
+
+            # Non-streaming
+            choices = []
+            total_completion = 0
+            for i in range(n):
+                num_tokens, finish_reason = _compute_output_length(
+                    max_tokens, config.eos_min_ratio, ignore_eos
+                )
+                text = render_dummy_text(num_tokens)
+                text, stopped = _check_stop_sequences(text, req.stop)
+                if stopped:
+                    finish_reason = "stop"
+                    num_tokens = max(1, len(text) // 4)
+                total_completion += num_tokens
+                lp_data = None
+                if req.logprobs:
+                    top_n = req.top_logprobs or 5
+                    lp_data = generate_chat_logprobs(tokenize_text(text), top_n)
+                choices.append(
+                    Choice(
+                        index=i,
+                        message=ChoiceMessage(role="assistant", content=text),
+                        finish_reason=finish_reason,
+                        logprobs=lp_data,
+                    )
+                )
+
+            # Simulate decode delay
+            decode_delay = _compute_decode_delay(config)
+            await asyncio.sleep(decode_delay * total_completion)
+
+            # Update metrics
+            config._metrics.inc_tokens(total_completion)
+
+            # Log request
+            total_ms = (time.monotonic() - request_start) * 1000
+            _log_request(
+                config,
+                prompt_tokens=prompt_tokens,
+                output_tokens=total_completion,
+                prefill_ms=prefill_delay * 1000,
+                kv_transfer_ms=kv_delay * 1000,
+                decode_ms=decode_delay * total_completion * 1000,
+                total_ms=total_ms,
             )
 
-        # Simulate decode delay
-        decode_delay = _compute_decode_delay(config)
-        await asyncio.sleep(decode_delay * total_completion)
-
-        return ChatCompletionResponse(
-            id=generate_id("chatcmpl"),
-            created=now_ts(),
-            model=config.model_name,
-            choices=choices,
-            usage=UsageInfo(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=total_completion,
-                total_tokens=prompt_tokens + total_completion,
-            ),
-            system_fingerprint=SYSTEM_FINGERPRINT,
-        )
+            return ChatCompletionResponse(
+                id=generate_id("chatcmpl"),
+                created=now_ts(),
+                model=config.model_name,
+                choices=choices,
+                usage=UsageInfo(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=total_completion,
+                    total_tokens=prompt_tokens + total_completion,
+                ),
+                system_fingerprint=SYSTEM_FINGERPRINT,
+            )
+        finally:
+            config._metrics.dec_active()
+            duration = time.monotonic() - request_start
+            config._metrics.observe_duration(duration)
 
     @app.post("/v1/completions")
     async def completions(request: Request):
+        request_start = time.monotonic()
+        config._metrics.inc_requests()
+        config._metrics.inc_active()
         try:
-            body = await request.json()
-        except Exception:
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "error": {"message": "Invalid JSON body", "type": "invalid_request_error"}
-                },
-            )
-        try:
-            req = CompletionRequest(**body)
-        except ValidationError as e:
-            return JSONResponse(
-                status_code=400,
-                content={"error": {"message": str(e), "type": "invalid_request_error"}},
-            )
-
-        prompt_tokens = count_prompt_tokens(prompt=req.prompt)
-        max_tokens = get_effective_max_tokens(req.max_tokens)
-        n = req.n or 1
-        ignore_eos = req.ignore_eos or False
-
-        # Simulate prefill + KV transfer
-        prefill_delay = _compute_prefill_delay(config, prompt_tokens)
-        kv_delay = _compute_kv_delay(config, prompt_tokens)
-        await asyncio.sleep(prefill_delay + kv_delay)
-
-        if req.stream:
-            return StreamingResponse(
-                _stream_completion(config, req, prompt_tokens, max_tokens, n, ignore_eos),
-                media_type="text/event-stream",
-            )
-
-        # Non-streaming
-        choices = []
-        total_completion = 0
-        for i in range(n):
-            num_tokens, finish_reason = _compute_output_length(
-                max_tokens, config.eos_min_ratio, ignore_eos
-            )
-            text = render_dummy_text(num_tokens)
-            text, stopped = _check_stop_sequences(text, req.stop)
-            if stopped:
-                finish_reason = "stop"
-                num_tokens = max(1, len(text) // 4)
-            total_completion += num_tokens
-            lp = None
-            if req.logprobs is not None and req.logprobs > 0:
-                tokens = list(text) if text else [""]
-                lp = generate_completion_logprobs(tokens, req.logprobs)
-            choices.append(
-                CompletionChoice(
-                    index=i,
-                    text=text,
-                    finish_reason=finish_reason,
-                    logprobs=lp,
+            try:
+                body = await request.json()
+            except Exception:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": {
+                            "message": "Invalid JSON body",
+                            "type": "invalid_request_error",
+                        }
+                    },
                 )
+            try:
+                req = CompletionRequest(**body)
+            except ValidationError as e:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": {"message": str(e), "type": "invalid_request_error"}},
+                )
+
+            prompt_tokens = count_prompt_tokens(prompt=req.prompt)
+            max_tokens = get_effective_max_tokens(req.max_tokens)
+            n = req.n or 1
+            ignore_eos = req.ignore_eos or False
+
+            # Warm-up penalty
+            warmup_penalty = (
+                config._warmup_tracker.get_penalty() if config._warmup_tracker else 0
+            )
+            if warmup_penalty > 0:
+                await asyncio.sleep(warmup_penalty)
+
+            # Simulate prefill + KV transfer
+            prefill_delay = _compute_prefill_delay(config, prompt_tokens)
+            kv_delay = _compute_kv_delay(config, prompt_tokens)
+            await asyncio.sleep(prefill_delay + kv_delay)
+
+            if req.stream:
+                return StreamingResponse(
+                    _stream_completion(config, req, prompt_tokens, max_tokens, n, ignore_eos),
+                    media_type="text/event-stream",
+                )
+
+            # Non-streaming
+            choices = []
+            total_completion = 0
+            for i in range(n):
+                num_tokens, finish_reason = _compute_output_length(
+                    max_tokens, config.eos_min_ratio, ignore_eos
+                )
+                text = render_dummy_text(num_tokens)
+                text, stopped = _check_stop_sequences(text, req.stop)
+                if stopped:
+                    finish_reason = "stop"
+                    num_tokens = max(1, len(text) // 4)
+                total_completion += num_tokens
+                lp = None
+                if req.logprobs is not None and req.logprobs > 0:
+                    tokens = list(text) if text else [""]
+                    lp = generate_completion_logprobs(tokens, req.logprobs)
+                choices.append(
+                    CompletionChoice(
+                        index=i,
+                        text=text,
+                        finish_reason=finish_reason,
+                        logprobs=lp,
+                    )
+                )
+
+            # Simulate decode delay
+            decode_delay = _compute_decode_delay(config)
+            await asyncio.sleep(decode_delay * total_completion)
+
+            # Update metrics
+            config._metrics.inc_tokens(total_completion)
+
+            # Log request
+            total_ms = (time.monotonic() - request_start) * 1000
+            _log_request(
+                config,
+                prompt_tokens=prompt_tokens,
+                output_tokens=total_completion,
+                prefill_ms=prefill_delay * 1000,
+                kv_transfer_ms=kv_delay * 1000,
+                decode_ms=decode_delay * total_completion * 1000,
+                total_ms=total_ms,
             )
 
-        # Simulate decode delay
-        decode_delay = _compute_decode_delay(config)
-        await asyncio.sleep(decode_delay * total_completion)
-
-        return CompletionResponse(
-            id=generate_id("cmpl"),
-            created=now_ts(),
-            model=config.model_name,
-            choices=choices,
-            usage=UsageInfo(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=total_completion,
-                total_tokens=prompt_tokens + total_completion,
-            ),
-            system_fingerprint=SYSTEM_FINGERPRINT,
-        )
+            return CompletionResponse(
+                id=generate_id("cmpl"),
+                created=now_ts(),
+                model=config.model_name,
+                choices=choices,
+                usage=UsageInfo(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=total_completion,
+                    total_tokens=prompt_tokens + total_completion,
+                ),
+                system_fingerprint=SYSTEM_FINGERPRINT,
+            )
+        finally:
+            config._metrics.dec_active()
+            duration = time.monotonic() - request_start
+            config._metrics.observe_duration(duration)
 
     return app
 
@@ -435,6 +542,9 @@ async def _stream_chat(
         )
         yield f"data: {chunk.model_dump_json()}\n\n"
 
+    # Update token metrics for streaming
+    config._metrics.inc_tokens(total_completion)
+
     # Usage chunk
     if include_usage:
         usage_chunk = ChatCompletionChunk(
@@ -521,6 +631,9 @@ async def _stream_completion(
             system_fingerprint=SYSTEM_FINGERPRINT,
         )
         yield f"data: {chunk.model_dump_json()}\n\n"
+
+    # Update token metrics for streaming
+    config._metrics.inc_tokens(total_completion)
 
     if include_usage:
         usage_chunk = CompletionChunk(

--- a/tests/test_m6_observability.py
+++ b/tests/test_m6_observability.py
@@ -1,0 +1,282 @@
+"""Tests for M6: Observability — TC10.1, TC10.2, TC10.3, TC10.4."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from xpyd_sim.server import ServerConfig, create_app
+
+
+@pytest.fixture()
+def client():
+    """Default client with zero delays for fast tests."""
+    config = ServerConfig(
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+    )
+    app = create_app(config)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.fixture()
+def warmup_client():
+    """Client with warmup enabled."""
+    config = ServerConfig(
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+        warmup_requests=3,
+        warmup_penalty_ms=100,
+    )
+    app = create_app(config)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.fixture()
+def logging_client(tmp_path: Path):
+    """Client with request logging enabled."""
+    log_file = tmp_path / "requests.jsonl"
+    config = ServerConfig(
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+        log_requests=str(log_file),
+    )
+    app = create_app(config)
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+    client._log_file = log_file  # type: ignore[attr-defined]
+    return client
+
+
+# TC10.1: /metrics endpoint — valid Prometheus format
+class TestMetricsEndpoint:
+    async def test_metrics_returns_prometheus_format(self, client: httpx.AsyncClient):
+        resp = await client.get("/metrics")
+        assert resp.status_code == 200
+        text = resp.text
+        assert "xpyd_sim_requests_total" in text
+        assert "xpyd_sim_tokens_generated_total" in text
+        assert "xpyd_sim_active_requests" in text
+        assert "xpyd_sim_request_duration_seconds" in text
+
+    async def test_metrics_has_correct_types(self, client: httpx.AsyncClient):
+        resp = await client.get("/metrics")
+        text = resp.text
+        assert "# TYPE xpyd_sim_requests_total counter" in text
+        assert "# TYPE xpyd_sim_tokens_generated_total counter" in text
+        assert "# TYPE xpyd_sim_active_requests gauge" in text
+        assert "# TYPE xpyd_sim_request_duration_seconds histogram" in text
+
+    async def test_metrics_increment_after_request(self, client: httpx.AsyncClient):
+        # Make a request
+        await client.post(
+            "/v1/chat/completions",
+            json={"model": "dummy", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        resp = await client.get("/metrics")
+        text = resp.text
+        # requests_total should be at least 1
+        for line in text.splitlines():
+            if line.startswith("xpyd_sim_requests_total "):
+                count = int(line.split()[-1])
+                assert count >= 1
+
+    async def test_metrics_tokens_generated(self, client: httpx.AsyncClient):
+        await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+            },
+        )
+        resp = await client.get("/metrics")
+        text = resp.text
+        for line in text.splitlines():
+            if line.startswith("xpyd_sim_tokens_generated_total "):
+                count = int(line.split()[-1])
+                assert count >= 1
+
+    async def test_metrics_histogram_buckets(self, client: httpx.AsyncClient):
+        await client.post(
+            "/v1/chat/completions",
+            json={"model": "dummy", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        resp = await client.get("/metrics")
+        text = resp.text
+        assert 'le="0.005"' in text
+        assert 'le="+Inf"' in text
+        assert "xpyd_sim_request_duration_seconds_sum" in text
+        assert "xpyd_sim_request_duration_seconds_count" in text
+
+    async def test_metrics_content_type(self, client: httpx.AsyncClient):
+        resp = await client.get("/metrics")
+        assert "text/plain" in resp.headers["content-type"]
+
+
+# TC10.2: Request logging — JSONL with correct fields
+class TestRequestLogging:
+    async def test_logging_creates_jsonl(self, logging_client: httpx.AsyncClient):
+        await logging_client.post(
+            "/v1/chat/completions",
+            json={"model": "dummy", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        log_file = logging_client._log_file  # type: ignore[attr-defined]
+        assert log_file.exists()
+        lines = log_file.read_text().strip().splitlines()
+        assert len(lines) >= 1
+        record = json.loads(lines[0])
+        assert "timestamp" in record
+        assert "prompt_tokens" in record
+        assert "output_tokens" in record
+        assert "prefill_ms" in record
+        assert "kv_transfer_ms" in record
+        assert "decode_ms" in record
+        assert "total_ms" in record
+        assert "mode" in record
+
+    async def test_logging_multiple_requests(self, logging_client: httpx.AsyncClient):
+        for _ in range(3):
+            await logging_client.post(
+                "/v1/chat/completions",
+                json={"model": "dummy", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        log_file = logging_client._log_file  # type: ignore[attr-defined]
+        lines = log_file.read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    async def test_logging_completions_endpoint(self, logging_client: httpx.AsyncClient):
+        await logging_client.post(
+            "/v1/completions",
+            json={"model": "dummy", "prompt": "hello"},
+        )
+        log_file = logging_client._log_file  # type: ignore[attr-defined]
+        lines = log_file.read_text().strip().splitlines()
+        assert len(lines) >= 1
+        record = json.loads(lines[0])
+        assert record["mode"] == "dual"
+
+    async def test_logging_records_correct_mode(self, tmp_path: Path):
+        log_file = tmp_path / "req.jsonl"
+        config = ServerConfig(
+            mode="prefill",
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+            log_requests=str(log_file),
+        )
+        app = create_app(config)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            await c.post(
+                "/v1/chat/completions",
+                json={"model": "dummy", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        record = json.loads(log_file.read_text().strip().splitlines()[0])
+        assert record["mode"] == "prefill"
+
+
+# TC10.3: /health returns mode and config
+class TestHealthEndpoint:
+    async def test_health_returns_mode(self, client: httpx.AsyncClient):
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["mode"] == "dual"
+
+    async def test_health_returns_model(self, client: httpx.AsyncClient):
+        resp = await client.get("/health")
+        data = resp.json()
+        assert "model" in data
+
+    async def test_health_returns_config(self, client: httpx.AsyncClient):
+        resp = await client.get("/health")
+        data = resp.json()
+        assert "config" in data
+        cfg = data["config"]
+        assert "prefill_delay_ms" in cfg
+        assert "kv_transfer_delay_ms" in cfg
+        assert "decode_delay_per_token_ms" in cfg
+
+    async def test_health_reflects_mode_config(self):
+        config = ServerConfig(
+            mode="decode",
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+        )
+        app = create_app(config)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get("/health")
+        data = resp.json()
+        assert data["mode"] == "decode"
+
+
+# TC10.4: Warm-up behavior — first N requests have extra latency
+class TestWarmup:
+    async def test_warmup_penalty_applied(self, warmup_client: httpx.AsyncClient):
+        """First 3 requests should be slower due to warmup penalty."""
+        import time
+
+        times = []
+        for _ in range(5):
+            start = time.monotonic()
+            await warmup_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "dummy",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                },
+            )
+            elapsed = time.monotonic() - start
+            times.append(elapsed)
+
+        # First 3 should each take >= 100ms (warmup penalty)
+        for i in range(3):
+            assert times[i] >= 0.08, f"Warmup request {i} too fast: {times[i]:.4f}s"
+
+        # Last 2 should be fast (no penalty, zero delays)
+        for i in range(3, 5):
+            assert times[i] < 0.08, f"Post-warmup request {i} too slow: {times[i]:.4f}s"
+
+    async def test_warmup_completions_endpoint(self):
+        """Warmup also applies to /v1/completions."""
+        import time
+
+        config = ServerConfig(
+            prefill_delay_ms=0,
+            kv_transfer_delay_ms=0,
+            decode_delay_per_token_ms=0,
+            warmup_requests=2,
+            warmup_penalty_ms=100,
+        )
+        app = create_app(config)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            times = []
+            for _ in range(4):
+                start = time.monotonic()
+                await c.post(
+                    "/v1/completions",
+                    json={"model": "dummy", "prompt": "hi", "max_tokens": 1},
+                )
+                elapsed = time.monotonic() - start
+                times.append(elapsed)
+
+            # First 2 should be slow
+            for i in range(2):
+                assert times[i] >= 0.08
+            # Last 2 should be fast
+            for i in range(2, 4):
+                assert times[i] < 0.08


### PR DESCRIPTION
## Summary

Implement M6: Observability milestone.

### Changes
- **New file:** `src/xpyd_sim/observability.py` — Metrics (Prometheus), RequestLogger (JSONL), WarmupTracker
- **Modified:** `src/xpyd_sim/server.py` — Instrumented both endpoints with metrics tracking, request logging, and warm-up penalty
- **New file:** `tests/test_m6_observability.py` — 16 tests covering TC10.1–TC10.4

### Features
- `/metrics` endpoint: Prometheus format with counters, gauge, histogram
- JSONL request logging: timestamp, token counts, latency breakdown, mode
- Warm-up simulation: first N requests get extra latency penalty
- `/health` already returns mode + config (verified, no changes needed)

### Test Results
All 112 tests pass (96 existing + 16 new).

Closes #11