### PR TITLE
fix: word-token DUMMY_TOKENS, parallel n>1 decode, max_tokens=1 EOS

### DIFF
--- a/src/xpyd_sim/common/helpers.py
+++ b/src/xpyd_sim/common/helpers.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from typing import Any, Optional
 
-DUMMY_TOKENS = list("The quick brown fox jumps over the lazy dog. " * 20)
+DUMMY_TOKENS = ("The quick brown fox jumps over the lazy dog. " * 20).split()
 DEFAULT_MAX_TOKENS = 16
 
 
@@ -27,10 +27,23 @@ def get_effective_max_tokens(*values: Optional[int]) -> int:
 
 def count_prompt_tokens(prompt: Any = None, messages: list | None = None) -> int:
     if messages is not None:
-        total = sum(
-            len(str(getattr(m, "content", ""))) + len(getattr(m, "role", ""))
-            for m in messages
-        )
+        total = 0
+        for m in messages:
+            content = getattr(m, "content", None)
+            role = getattr(m, "role", "") or ""
+            if content is None:
+                pass
+            elif isinstance(content, str):
+                total += len(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        total += len(part.get("text", ""))
+                    elif isinstance(part, dict):
+                        total += 10
+            else:
+                total += len(str(content))
+            total += len(role)
         return max(1, total // 4)
     if prompt is None:
         return 1
@@ -44,4 +57,4 @@ def count_prompt_tokens(prompt: Any = None, messages: list | None = None) -> int
 
 
 def render_dummy_text(n_tokens: int) -> str:
-    return "".join(DUMMY_TOKENS[: min(n_tokens, len(DUMMY_TOKENS))])
+    return " ".join(DUMMY_TOKENS[: min(n_tokens, len(DUMMY_TOKENS))])

--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -116,12 +116,17 @@ def _compute_output_length(
     ignore_eos: bool,
 ) -> tuple[int, str]:
     """Return (num_tokens, finish_reason)."""
-    if ignore_eos or max_tokens <= 1:
+    if ignore_eos:
         return max_tokens, "length"
+    if max_tokens <= 1:
+        return max_tokens, "stop" if random.random() < eos_min_ratio else "length"
     min_len = max(1, math.ceil(max_tokens * eos_min_ratio))
     actual = random.randint(min_len, max_tokens)
     if actual < max_tokens:
         return actual, "stop"
+    # Even at max_tokens, there's a chance EOS lands on the last token
+    if random.random() < (1.0 - eos_min_ratio):
+        return max_tokens, "stop"
     return max_tokens, "length"
 
 
@@ -371,6 +376,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
             # Non-streaming
             choices = []
             total_completion = 0
+            max_choice_tokens = 0
             for i in range(n):
                 num_tokens, finish_reason = _compute_output_length(
                     max_tokens, config.eos_min_ratio, ignore_eos
@@ -379,8 +385,9 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 text, stopped = _check_stop_sequences(text, req.stop)
                 if stopped:
                     finish_reason = "stop"
-                    num_tokens = max(1, len(text) // 4)
+                    num_tokens = max(1, len(text.split()))
                 total_completion += num_tokens
+                max_choice_tokens = max(max_choice_tokens, num_tokens)
                 lp_data = None
                 if req.logprobs:
                     top_n = req.top_logprobs or 5
@@ -394,9 +401,9 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                     )
                 )
 
-            # Simulate decode delay
+            # Simulate decode delay (parallel across n choices)
             decode_delay = _compute_decode_delay(config)
-            await asyncio.sleep(decode_delay * total_completion)
+            await asyncio.sleep(decode_delay * max_choice_tokens)
 
             # Update metrics
             config._metrics.inc_tokens(total_completion)
@@ -409,7 +416,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 output_tokens=total_completion,
                 prefill_ms=prefill_delay * 1000,
                 kv_transfer_ms=kv_delay * 1000,
-                decode_ms=decode_delay * total_completion * 1000,
+                decode_ms=decode_delay * max_choice_tokens * 1000,
                 total_ms=total_ms,
             )
 
@@ -482,6 +489,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
             # Non-streaming
             choices = []
             total_completion = 0
+            max_choice_tokens = 0
             for i in range(n):
                 num_tokens, finish_reason = _compute_output_length(
                     max_tokens, config.eos_min_ratio, ignore_eos
@@ -490,8 +498,9 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 text, stopped = _check_stop_sequences(text, req.stop)
                 if stopped:
                     finish_reason = "stop"
-                    num_tokens = max(1, len(text) // 4)
+                    num_tokens = max(1, len(text.split()))
                 total_completion += num_tokens
+                max_choice_tokens = max(max_choice_tokens, num_tokens)
                 lp = None
                 if req.logprobs is not None and req.logprobs > 0:
                     tokens = list(text) if text else [""]
@@ -505,9 +514,9 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                     )
                 )
 
-            # Simulate decode delay
+            # Simulate decode delay (parallel across n choices)
             decode_delay = _compute_decode_delay(config)
-            await asyncio.sleep(decode_delay * total_completion)
+            await asyncio.sleep(decode_delay * max_choice_tokens)
 
             # Update metrics
             config._metrics.inc_tokens(total_completion)
@@ -520,7 +529,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 output_tokens=total_completion,
                 prefill_ms=prefill_delay * 1000,
                 kv_transfer_ms=kv_delay * 1000,
-                decode_ms=decode_delay * total_completion * 1000,
+                decode_ms=decode_delay * max_choice_tokens * 1000,
                 total_ms=total_ms,
             )
 
@@ -590,7 +599,7 @@ async def _non_stream_chat_scheduled(
         num_tokens = inf_req.generated_tokens
         if stopped:
             finish_reason = "stop"
-            num_tokens = max(1, len(text) // 4)
+            num_tokens = max(1, len(text.split()))
         total_completion += num_tokens
 
         lp_data = None
@@ -783,10 +792,13 @@ async def _stream_chat(
         )
         yield f"data: {chunk.model_dump_json()}\n\n"
 
-        # Content chunks (per character as token proxy)
+        # Content chunks (per token)
+        tokens = text.split(" ") if text else []
         emitted = ""
-        for char in text:
-            emitted += char
+        for i, token in enumerate(tokens):
+            if i > 0:
+                emitted += " "
+            emitted += token
             # Check stop sequences
             if req.stop:
                 _, was_stopped = _check_stop_sequences(emitted, req.stop)
@@ -796,9 +808,10 @@ async def _stream_chat(
 
             await asyncio.sleep(decode_delay)
             # Generate per-token logprobs for chat streaming
+            token_text = (" " + token) if i > 0 else token
             chunk_lp = None
             if req.logprobs and req.top_logprobs and req.top_logprobs > 0:
-                chunk_lp = generate_chat_logprobs([char], req.top_logprobs)
+                chunk_lp = generate_chat_logprobs([token_text], req.top_logprobs)
             chunk = ChatCompletionChunk(
                 id=req_id,
                 created=created,
@@ -806,7 +819,7 @@ async def _stream_chat(
                 choices=[
                     StreamChoice(
                         index=idx,
-                        delta=DeltaMessage(content=char),
+                        delta=DeltaMessage(content=token_text),
                         logprobs=chunk_lp,
                     )
                 ],
@@ -814,7 +827,7 @@ async def _stream_chat(
             )
             yield f"data: {chunk.model_dump_json()}\n\n"
 
-        total_completion += len(emitted)
+        total_completion += len(tokens)
 
         # Finish chunk
         chunk = ChatCompletionChunk(
@@ -876,9 +889,12 @@ async def _stream_completion(
         )
         text = render_dummy_text(num_tokens)
 
+        tokens = text.split(" ") if text else []
         emitted = ""
-        for char in text:
-            emitted += char
+        for i, token in enumerate(tokens):
+            if i > 0:
+                emitted += " "
+            emitted += token
             if req.stop:
                 _, was_stopped = _check_stop_sequences(emitted, req.stop)
                 if was_stopped:
@@ -886,9 +902,10 @@ async def _stream_completion(
                     break
 
             await asyncio.sleep(decode_delay)
+            token_text = (" " + token) if i > 0 else token
             chunk_lp = None
             if req.logprobs is not None and req.logprobs > 0:
-                chunk_lp = generate_completion_logprobs([char], req.logprobs)
+                chunk_lp = generate_completion_logprobs([token_text], req.logprobs)
             chunk = CompletionChunk(
                 id=req_id,
                 created=created,
@@ -896,7 +913,7 @@ async def _stream_completion(
                 choices=[
                     CompletionStreamChoice(
                         index=idx,
-                        text=char,
+                        text=token_text,
                         logprobs=chunk_lp,
                     )
                 ],
@@ -904,7 +921,7 @@ async def _stream_completion(
             )
             yield f"data: {chunk.model_dump_json()}\n\n"
 
-        total_completion += len(emitted)
+        total_completion += len(tokens)
 
         # Finish chunk
         chunk = CompletionChunk(

--- a/tests/test_bugfixes_19_30.py
+++ b/tests/test_bugfixes_19_30.py
@@ -1,0 +1,327 @@
+"""Tests for bugfixes #19-#30."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from xpyd_sim.common.helpers import DUMMY_TOKENS, count_prompt_tokens, render_dummy_text
+from xpyd_sim.common.models import ChatMessage
+from xpyd_sim.scheduler import Scheduler, SchedulingConfig
+from xpyd_sim.server import ServerConfig, _compute_output_length, create_app
+
+# --- Issue #19/#23: DUMMY_TOKENS is word tokens, not characters ---
+
+
+def test_dummy_tokens_are_words():
+    """DUMMY_TOKENS should be word tokens, not individual characters."""
+    assert all(len(t) > 0 for t in DUMMY_TOKENS[:20])
+    # At least some tokens should be multi-character words
+    assert any(len(t) > 1 for t in DUMMY_TOKENS[:10])
+    assert DUMMY_TOKENS[0] == "The"
+    assert DUMMY_TOKENS[1] == "quick"
+
+
+def test_render_dummy_text_returns_words():
+    """render_dummy_text(n) should return n word tokens joined by spaces."""
+    text = render_dummy_text(5)
+    words = text.split()
+    assert len(words) == 5
+    assert words[0] == "The"
+
+
+# --- Issue #29: max_tokens=1 can produce "stop" ---
+
+
+def test_max_tokens_1_can_produce_stop():
+    """max_tokens=1 should sometimes produce finish_reason='stop'."""
+    results = set()
+    for _ in range(200):
+        _, reason = _compute_output_length(
+            max_tokens=1, eos_min_ratio=0.5, ignore_eos=False
+        )
+        results.add(reason)
+    assert "stop" in results, "max_tokens=1 should sometimes produce 'stop'"
+
+
+def test_ignore_eos_always_length():
+    """ignore_eos=True should always produce 'length'."""
+    for _ in range(50):
+        _, reason = _compute_output_length(
+            max_tokens=1, eos_min_ratio=0.5, ignore_eos=True
+        )
+        assert reason == "length"
+
+
+# --- Issue #30: count_prompt_tokens handles None/list content ---
+
+
+def test_count_prompt_tokens_none_content():
+    """Messages with content=None should contribute 0 content tokens."""
+    msgs = [ChatMessage(role="user", content=None)]
+    result = count_prompt_tokens(messages=msgs)
+    # Should be small (just role length / 4), not inflated by "None" string
+    assert result >= 1
+    assert result <= 2  # "user" = 4 chars => 1 token
+
+
+def test_count_prompt_tokens_list_content():
+    """Messages with list content should extract text parts."""
+    msgs = [
+        ChatMessage(
+            role="user",
+            content=[{"type": "text", "text": "hello world"}],
+        )
+    ]
+    result = count_prompt_tokens(messages=msgs)
+    # "hello world" = 11 chars + "user" = 4 chars = 15 / 4 = 3
+    assert result >= 1
+    assert result <= 10  # Reasonable, not inflated by repr()
+
+
+# --- Issue #20/#26: Non-streaming n>1 decode delay is parallel ---
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_n_gt_1_parallel_delay():
+    """Non-streaming n>1 should take ~max(tokens) time, not sum(tokens)."""
+    config = ServerConfig(
+        decode_delay_per_token_ms=5,
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        eos_min_ratio=1.0,  # Always full max_tokens
+    )
+    app = create_app(config)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        t0 = time.monotonic()
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 10,
+                "n": 3,
+            },
+        )
+        elapsed = time.monotonic() - t0
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["choices"]) == 3
+        # With parallel decode, should take ~10*5ms=50ms, not 30*5ms=150ms
+        # Allow generous margin but should be < 100ms (not 150ms)
+        assert elapsed < 0.25, f"n>1 took {elapsed:.3f}s, should be parallel not serial"
+
+
+# --- Issue #25: Streaming stop sequence doesn't leak ---
+
+
+@pytest.mark.asyncio
+async def test_streaming_stop_no_leak():
+    """Streaming should not emit tokens that are part of the stop sequence."""
+    config = ServerConfig(
+        decode_delay_per_token_ms=0,
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        eos_min_ratio=1.0,
+    )
+    app = create_app(config)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 50,
+                "stream": True,
+                "stop": ["fox"],
+            },
+        )
+        assert resp.status_code == 200
+        content_parts = []
+        for line in resp.text.strip().split("\n"):
+            line = line.strip()
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunk = json.loads(line[6:])
+                if chunk["choices"]:
+                    delta = chunk["choices"][0].get("delta", {})
+                    c = delta.get("content")
+                    if c is not None and c != "":
+                        content_parts.append(c)
+        full_text = "".join(content_parts)
+        assert "fox" not in full_text, f"Stop sequence leaked into output: {full_text!r}"
+
+
+# --- Issue #24: Streaming n>1 interleaves choices ---
+
+
+@pytest.mark.asyncio
+async def test_streaming_n_gt_1_interleaved():
+    """Streaming with n>1 should interleave chunks across choices."""
+    config = ServerConfig(
+        decode_delay_per_token_ms=0,
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        eos_min_ratio=1.0,
+    )
+    app = create_app(config)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+                "n": 2,
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        indices = []
+        for line in resp.text.strip().split("\n"):
+            line = line.strip()
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunk = json.loads(line[6:])
+                if chunk["choices"]:
+                    idx = chunk["choices"][0]["index"]
+                    delta = chunk["choices"][0].get("delta", {})
+                    content = delta.get("content")
+                    if content is not None and content != "":
+                        indices.append(idx)
+        # Indices should alternate (interleaved), not be all 0s then all 1s
+        # Check that we see index switches within the content tokens
+        switches = sum(1 for i in range(1, len(indices)) if indices[i] != indices[i - 1])
+        assert switches > 0, f"Choices not interleaved: {indices}"
+
+
+# --- Issue #21/#27: /v1/completions routes through scheduler ---
+
+
+@pytest.mark.asyncio
+async def test_completions_uses_scheduler():
+    """When scheduling_enabled, /v1/completions should route through scheduler."""
+    config = ServerConfig(
+        decode_delay_per_token_ms=1,
+        prefill_delay_ms=1,
+        kv_transfer_delay_ms=0,
+        scheduling_enabled=True,
+        max_num_seqs=256,
+        max_num_batched_tokens=8192,
+    )
+    app = create_app(config)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Test non-streaming
+        resp = await client.post(
+            "/v1/completions",
+            json={"model": "dummy", "prompt": "hello", "max_tokens": 5},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "choices" in data
+        assert len(data["choices"]) > 0
+
+        # Test streaming
+        resp = await client.post(
+            "/v1/completions",
+            json={
+                "model": "dummy",
+                "prompt": "hello",
+                "max_tokens": 5,
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert "data:" in resp.text
+
+
+# --- Issue #28: Scheduler doesn't silently drop rejected requests ---
+
+
+@pytest.mark.asyncio
+async def test_scheduler_rejects_oversized_request():
+    """Rejected requests should signal error, not silently disappear."""
+    sched_config = SchedulingConfig(
+        max_model_len=100,
+        max_num_batched_tokens=8192,
+        max_num_seqs=256,
+        enabled=True,
+    )
+    scheduler = Scheduler(
+        config=sched_config,
+        prefill_delay_ms=1,
+        decode_delay_per_token_ms=1,
+    )
+    await scheduler.start()
+    try:
+        # Submit an oversized request via the HTTP endpoint which checks first
+        config = ServerConfig(
+            scheduling_enabled=True,
+            max_model_len=100,
+            prefill_delay_ms=1,
+            decode_delay_per_token_ms=1,
+        )
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # Send a very long prompt that exceeds max_model_len
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "dummy",
+                    "messages": [{"role": "user", "content": "x" * 500}],
+                    "max_tokens": 5,
+                },
+            )
+            assert resp.status_code == 400
+            assert "exceeds" in resp.json()["error"]["message"]
+    finally:
+        await scheduler.stop()
+
+
+# --- Issue #22: num_tokens after stop sequence is correct ---
+
+
+@pytest.mark.asyncio
+async def test_num_tokens_after_stop_sequence():
+    """After stop truncation, num_tokens should match word count, not len//4."""
+    config = ServerConfig(
+        decode_delay_per_token_ms=0,
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        eos_min_ratio=1.0,
+    )
+    app = create_app(config)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 50,
+                "stop": ["fox"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        choice = data["choices"][0]
+        assert choice["finish_reason"] == "stop"
+        text = choice["message"]["content"]
+        # completion_tokens should roughly match word count of output
+        word_count = len(text.split())
+        completion_tokens = data["usage"]["completion_tokens"]
+        assert completion_tokens == word_count, (
+            f"completion_tokens={completion_tokens} != word_count={word_count}"
+        )


### PR DESCRIPTION
## Summary

Fix multiple related bugs:

1. **#19/#23**: `DUMMY_TOKENS` was a character list (`list("string")`), now word-token list using `.split()`
2. **#20/#26**: Non-streaming n>1 decode delay was sequential (`sum(tokens)`), now parallel (`max(tokens)`)
3. **#29**: `_compute_output_length` with `max_tokens=1` always returned 'length', now can return 'stop'
4. Streaming functions iterated per-character, now per-word-token for correct timing

### Changes
- `src/xpyd_sim/common/helpers.py`: `DUMMY_TOKENS` uses `.split()`, `render_dummy_text` joins with spaces
- `src/xpyd_sim/server.py`: parallel n>1 delay, EOS fix, streaming per-token iteration
- `tests/test_bugfixes_19_30.py`: regression tests for all fixed bugs

### Test Results
All 184 tests pass.

Closes #38