### PR TITLE
fix: echo=True support and replace deprecated get_event_loop()

### DIFF
--- a/src/xpyd_sim/scheduler.py
+++ b/src/xpyd_sim/scheduler.py
@@ -326,7 +326,7 @@ class Scheduler:
         for req in queue:
             if req.input_tokens > self.config.max_model_len:
                 # Reject: signal error via token queue
-                asyncio.get_event_loop().call_soon(
+                asyncio.get_running_loop().call_soon(
                     lambda r=req: r.token_queue.put_nowait(
                         (
                             "error",
@@ -335,7 +335,7 @@ class Scheduler:
                         )
                     )
                 )
-                asyncio.get_event_loop().call_soon(lambda r=req: r.done_event.set())
+                asyncio.get_running_loop().call_soon(lambda r=req: r.done_event.set())
                 continue
             if current_tokens + req.input_tokens > self.config.max_num_batched_tokens:
                 remaining.append(req)

--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -501,14 +501,21 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                     num_tokens = max(1, len(text.split()))
                 total_completion += num_tokens
                 max_choice_tokens = max(max_choice_tokens, num_tokens)
+
+                # echo=True: prepend prompt text to output
+                output_text = text
+                if req.echo:
+                    prompt_str = req.prompt if isinstance(req.prompt, str) else str(req.prompt)
+                    output_text = prompt_str + text
+
                 lp = None
                 if req.logprobs is not None and req.logprobs > 0:
-                    tokens = list(text) if text else [""]
+                    tokens = list(output_text) if output_text else [""]
                     lp = generate_completion_logprobs(tokens, req.logprobs)
                 choices.append(
                     CompletionChoice(
                         index=i,
-                        text=text,
+                        text=output_text,
                         finish_reason=finish_reason,
                         logprobs=lp,
                     )
@@ -888,6 +895,24 @@ async def _stream_completion(
             max_tokens, config.eos_min_ratio, ignore_eos
         )
         text = render_dummy_text(num_tokens)
+
+        # echo=True: emit prompt text first
+        if req.echo:
+            prompt_str = req.prompt if isinstance(req.prompt, str) else str(req.prompt)
+            echo_chunk = CompletionChunk(
+                id=req_id,
+                created=created,
+                model=config.model_name,
+                choices=[
+                    CompletionStreamChoice(
+                        index=idx,
+                        text=prompt_str,
+                        logprobs=None,
+                    )
+                ],
+                system_fingerprint=SYSTEM_FINGERPRINT,
+            )
+            yield f"data: {echo_chunk.model_dump_json()}\n\n"
 
         tokens = text.split(" ") if text else []
         emitted = ""

--- a/tests/test_bugfixes_31_32.py
+++ b/tests/test_bugfixes_31_32.py
@@ -1,0 +1,98 @@
+"""Tests for bugfixes #31 (echo=True) and #32 (deprecated get_event_loop)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from xpyd_sim.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def config():
+    return ServerConfig(
+        mode="dual",
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+        eos_min_ratio=1.0,
+    )
+
+
+@pytest.fixture
+def app(config):
+    return create_app(config)
+
+
+# --- Issue #31: echo=True on /v1/completions ---
+
+
+@pytest.mark.anyio
+async def test_echo_true_non_streaming(app):
+    """echo=True should prepend prompt text to completion output."""
+    prompt = "Hello world"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/completions",
+            json={"model": "dummy", "prompt": prompt, "max_tokens": 5, "echo": True},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    text = data["choices"][0]["text"]
+    assert text.startswith(prompt), f"Expected text to start with prompt, got: {text!r}"
+
+
+@pytest.mark.anyio
+async def test_echo_false_non_streaming(app):
+    """echo=False (default) should NOT prepend prompt."""
+    prompt = "Hello world"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/completions",
+            json={"model": "dummy", "prompt": prompt, "max_tokens": 5, "echo": False},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    text = data["choices"][0]["text"]
+    assert not text.startswith(prompt)
+
+
+@pytest.mark.anyio
+async def test_echo_true_streaming(app):
+    """echo=True in streaming mode should emit prompt as first chunk."""
+    prompt = "Hello world"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/completions",
+            json={
+                "model": "dummy",
+                "prompt": prompt,
+                "max_tokens": 5,
+                "stream": True,
+                "echo": True,
+            },
+        )
+    assert resp.status_code == 200
+    chunks = []
+    for line in resp.text.split("\n"):
+        if line.startswith("data: ") and line.strip() != "data: [DONE]":
+            chunks.append(json.loads(line[6:]))
+    # First content chunk should be the prompt
+    assert len(chunks) > 0
+    assert chunks[0]["choices"][0]["text"] == prompt
+
+
+# --- Issue #32: asyncio.get_event_loop deprecation ---
+
+
+def test_scheduler_no_get_event_loop():
+    """Scheduler should use get_running_loop() not get_event_loop()."""
+    import inspect
+
+    from xpyd_sim import scheduler
+
+    source = inspect.getsource(scheduler)
+    assert "get_event_loop()" not in source, "Scheduler still uses deprecated get_event_loop()"
+    assert "get_running_loop()" in source


### PR DESCRIPTION
## Changes

1. **echo=True on /v1/completions** (#31): Prepends prompt text to completion output in both streaming and non-streaming modes
2. **Deprecated asyncio.get_event_loop()** (#32): Replace with asyncio.get_running_loop() in scheduler

## Tests Added
- test_echo_true_non_streaming - verifies output starts with prompt
- test_echo_false_non_streaming - verifies default behavior unchanged
- test_echo_true_streaming - verifies prompt emitted as first chunk
- test_scheduler_no_get_event_loop - verifies no deprecated calls

All 188 tests pass.

Closes #31
Closes #32
Closes #41