### PR TITLE
fix: align scheduler _compute_output_length with server for max_tokens=1

### DIFF
--- a/src/xpyd_sim/scheduler.py
+++ b/src/xpyd_sim/scheduler.py
@@ -62,14 +62,23 @@ class InferenceRequest:
 
     def _compute_output_length(self) -> None:
         mt = self.max_tokens
-        if self.ignore_eos or mt <= 1:
+        if self.ignore_eos:
             self.target_output_tokens = mt
             self.finish_reason = "length"
+            return
+        if mt <= 1:
+            self.target_output_tokens = mt
+            self.finish_reason = (
+                "stop" if random.random() < self.eos_min_ratio else "length"
+            )
             return
         min_len = max(1, math.ceil(mt * self.eos_min_ratio))
         actual = random.randint(min_len, mt)
         if actual < mt:
             self.target_output_tokens = actual
+            self.finish_reason = "stop"
+        elif random.random() < (1.0 - self.eos_min_ratio):
+            self.target_output_tokens = mt
             self.finish_reason = "stop"
         else:
             self.target_output_tokens = mt

--- a/tests/test_bugfix_29.py
+++ b/tests/test_bugfix_29.py
@@ -1,0 +1,78 @@
+"""Test fix for issue #29: _compute_output_length with max_tokens=1."""
+
+from __future__ import annotations
+
+import random
+
+from xpyd_sim.scheduler import InferenceRequest
+from xpyd_sim.server import _compute_output_length
+
+
+class TestComputeOutputLengthMaxTokens1:
+    """Both server and scheduler should allow finish_reason='stop' when max_tokens=1."""
+
+    def test_server_max_tokens_1_can_stop(self) -> None:
+        """Server _compute_output_length with max_tokens=1 can return 'stop'."""
+        random.seed(42)
+        reasons = set()
+        for _ in range(200):
+            _, reason = _compute_output_length(
+                max_tokens=1, eos_min_ratio=0.5, ignore_eos=False
+            )
+            reasons.add(reason)
+        assert "stop" in reasons, "max_tokens=1 should sometimes produce 'stop'"
+        assert "length" in reasons, "max_tokens=1 should sometimes produce 'length'"
+
+    def test_scheduler_max_tokens_1_can_stop(self) -> None:
+        """Scheduler InferenceRequest with max_tokens=1 can return 'stop'."""
+        random.seed(42)
+        reasons = set()
+        for _ in range(200):
+            req = InferenceRequest(
+                request_id=f"test-{_}",
+                input_tokens=10,
+                max_tokens=1,
+                eos_min_ratio=0.5,
+                ignore_eos=False,
+            )
+            reasons.add(req.finish_reason)
+        assert "stop" in reasons, "scheduler max_tokens=1 should sometimes produce 'stop'"
+        assert "length" in reasons, "scheduler max_tokens=1 should sometimes produce 'length'"
+
+    def test_ignore_eos_still_returns_length(self) -> None:
+        """ignore_eos=True should always return 'length' regardless of max_tokens."""
+        for _ in range(50):
+            _, reason = _compute_output_length(
+                max_tokens=1, eos_min_ratio=0.5, ignore_eos=True
+            )
+            assert reason == "length"
+
+    def test_scheduler_ignore_eos_still_returns_length(self) -> None:
+        """Scheduler ignore_eos=True should always return 'length'."""
+        for _ in range(50):
+            req = InferenceRequest(
+                request_id=f"test-{_}",
+                input_tokens=10,
+                max_tokens=1,
+                eos_min_ratio=0.5,
+                ignore_eos=True,
+            )
+            assert req.finish_reason == "length"
+
+    def test_scheduler_eos_on_last_token(self) -> None:
+        """Scheduler should sometimes return 'stop' even when actual==max_tokens."""
+        random.seed(0)
+        reasons = set()
+        for _ in range(500):
+            req = InferenceRequest(
+                request_id=f"test-{_}",
+                input_tokens=10,
+                max_tokens=10,
+                eos_min_ratio=0.1,
+                ignore_eos=False,
+            )
+            if req.target_output_tokens == req.max_tokens:
+                reasons.add(req.finish_reason)
+        assert "stop" in reasons, (
+            "scheduler should sometimes return 'stop' even at max_tokens"
+        )


### PR DESCRIPTION
## Summary

Fix scheduler's `_compute_output_length` to match server implementation:

1. **max_tokens=1 can now return `finish_reason='stop'`**: Removed overly broad `max_tokens <= 1` guard that always returned `'length'`. Now uses probabilistic EOS check (same as server).

2. **EOS on last token**: Added logic so that even when `actual == max_tokens`, there's a chance of returning `'stop'` based on `eos_min_ratio` (matching server behavior).

## Changes

- **`src/xpyd_sim/scheduler.py`**: Updated `InferenceRequest._compute_output_length()` to handle `max_tokens <= 1` probabilistically and add EOS-on-last-token logic
- **`tests/test_bugfix_29.py`**: 5 test cases covering both server and scheduler edge cases

## Test Results
All 194 tests pass.

Closes #29