### PR TITLE
fix: pre-truncate stop sequences before streaming to prevent partial leakage

### DIFF
--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -682,29 +682,31 @@ async def _stream_chat_scheduled(
         )
         yield f"data: {chunk.model_dump_json()}\n\n"
 
-        # Wait for tokens from scheduler
-        text_so_far = ""
+        # Collect all tokens from scheduler first, then apply stop
+        # truncation and stream the safe output.
+        token_count = 0
         while True:
             msg_type, value = await inf_req.token_queue.get()
             if msg_type == "error":
                 break
             if msg_type == "done":
                 break
-            # msg_type == "token"
-            token_idx = value
-            char = render_dummy_text(token_idx)[-1] if token_idx > 0 else "T"
-            text_so_far += char
+            token_count += 1
 
-            # Check stop sequences
-            finish_early = False
-            if req.stop:
-                _, was_stopped = _check_stop_sequences(text_so_far, req.stop)
-                if was_stopped:
-                    finish_early = True
+        # Build full text, apply stop truncation, then stream
+        text = render_dummy_text(token_count)
+        finish_reason_override = None
+        if req.stop:
+            text, was_stopped = _check_stop_sequences(text, req.stop)
+            if was_stopped:
+                finish_reason_override = "stop"
 
+        tokens = text.split(" ") if text else []
+        for i, token in enumerate(tokens):
+            token_text = (" " + token) if i > 0 else token
             chunk_lp = None
             if req.logprobs and req.top_logprobs and req.top_logprobs > 0:
-                chunk_lp = generate_chat_logprobs([char], req.top_logprobs)
+                chunk_lp = generate_chat_logprobs([token_text], req.top_logprobs)
             chunk = ChatCompletionChunk(
                 id=req_id,
                 created=created,
@@ -712,7 +714,7 @@ async def _stream_chat_scheduled(
                 choices=[
                     StreamChoice(
                         index=idx,
-                        delta=DeltaMessage(content=char),
+                        delta=DeltaMessage(content=token_text),
                         logprobs=chunk_lp,
                     )
                 ],
@@ -721,11 +723,11 @@ async def _stream_chat_scheduled(
             yield f"data: {chunk.model_dump_json()}\n\n"
             total_completion += 1
 
-            if finish_early:
-                break
-
         # Finish chunk
-        finish_reason = inf_req.finish_reason if inf_req.is_done() else "stop"
+        if finish_reason_override:
+            finish_reason = finish_reason_override
+        else:
+            finish_reason = inf_req.finish_reason if inf_req.is_done() else "stop"
         chunk = ChatCompletionChunk(
             id=req_id,
             created=created,
@@ -799,20 +801,16 @@ async def _stream_chat(
         )
         yield f"data: {chunk.model_dump_json()}\n\n"
 
+        # Apply stop sequence truncation before streaming (ensures identical
+        # output to non-streaming mode).
+        if req.stop:
+            text, stopped = _check_stop_sequences(text, req.stop)
+            if stopped:
+                finish_reason = "stop"
+
         # Content chunks (per token)
         tokens = text.split(" ") if text else []
-        emitted = ""
         for i, token in enumerate(tokens):
-            if i > 0:
-                emitted += " "
-            emitted += token
-            # Check stop sequences
-            if req.stop:
-                _, was_stopped = _check_stop_sequences(emitted, req.stop)
-                if was_stopped:
-                    finish_reason = "stop"
-                    break
-
             await asyncio.sleep(decode_delay)
             # Generate per-token logprobs for chat streaming
             token_text = (" " + token) if i > 0 else token
@@ -914,18 +912,14 @@ async def _stream_completion(
             )
             yield f"data: {echo_chunk.model_dump_json()}\n\n"
 
-        tokens = text.split(" ") if text else []
-        emitted = ""
-        for i, token in enumerate(tokens):
-            if i > 0:
-                emitted += " "
-            emitted += token
-            if req.stop:
-                _, was_stopped = _check_stop_sequences(emitted, req.stop)
-                if was_stopped:
-                    finish_reason = "stop"
-                    break
+        # Apply stop sequence truncation before streaming
+        if req.stop:
+            text, stopped = _check_stop_sequences(text, req.stop)
+            if stopped:
+                finish_reason = "stop"
 
+        tokens = text.split(" ") if text else []
+        for i, token in enumerate(tokens):
             await asyncio.sleep(decode_delay)
             token_text = (" " + token) if i > 0 else token
             chunk_lp = None

--- a/tests/test_bugfix_25.py
+++ b/tests/test_bugfix_25.py
@@ -1,0 +1,156 @@
+"""Tests for fix: streaming stop sequence should not leak partial stop chars.
+
+Verifies that streaming output with stop sequences is identical to
+non-streaming output — no partial stop sequence characters are emitted.
+
+Closes #25, #34
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_sim.server import ServerConfig, create_app
+
+
+@pytest.fixture()
+def app():
+    cfg = ServerConfig(
+        mode="dual",
+        prefill_delay_ms=0,
+        kv_transfer_delay_ms=0,
+        decode_delay_per_token_ms=0,
+        eos_min_ratio=1.0,
+    )
+    return create_app(config=cfg)
+
+
+@pytest.fixture()
+def client(app):
+    from starlette.testclient import TestClient
+
+    return TestClient(app)
+
+
+def _collect_stream_content(response) -> tuple[str, str | None]:
+    """Collect streamed content and finish_reason from SSE response."""
+    content = ""
+    finish_reason = None
+    for line in response.iter_lines():
+        if not line or not line.startswith("data: "):
+            continue
+        data = line[len("data: "):]
+        if data == "[DONE]":
+            break
+        chunk = json.loads(data)
+        choices = chunk.get("choices", [])
+        if not choices:
+            continue
+        choice = choices[0]
+        # Chat format
+        delta = choice.get("delta", {})
+        if delta and delta.get("content") is not None:
+            content += delta["content"]
+        # Completion format
+        text = choice.get("text")
+        if text is not None:
+            content += text
+        fr = choice.get("finish_reason")
+        if fr is not None:
+            finish_reason = fr
+    return content, finish_reason
+
+
+class TestStreamingStopSequenceChat:
+    """Chat endpoint: streaming stop should match non-streaming."""
+
+    def test_stop_single_word(self, client):
+        """Stop on a single word token — no partial leakage."""
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 20,
+            "stop": ["fox"],
+        }
+        # Non-streaming
+        resp_ns = client.post("/v1/chat/completions", json=body)
+        ns_text = resp_ns.json()["choices"][0]["message"]["content"]
+
+        # Streaming
+        body["stream"] = True
+        resp_s = client.post("/v1/chat/completions", json=body)
+        s_text, s_fr = _collect_stream_content(resp_s)
+
+        assert s_text == ns_text
+        assert "fox" not in s_text
+        assert s_fr == "stop"
+
+    def test_stop_cross_token_boundary(self, client):
+        """Stop sequence that spans token boundary (e.g. 'wn f' in 'brown fox')."""
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 20,
+            "stop": ["wn f"],
+        }
+        resp_ns = client.post("/v1/chat/completions", json=body)
+        ns_text = resp_ns.json()["choices"][0]["message"]["content"]
+
+        body["stream"] = True
+        resp_s = client.post("/v1/chat/completions", json=body)
+        s_text, _ = _collect_stream_content(resp_s)
+
+        assert s_text == ns_text
+        assert "wn f" not in s_text
+
+    def test_no_stop_full_output(self, client):
+        """Without stop sequences, streaming and non-streaming match."""
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 10,
+        }
+        resp_ns = client.post("/v1/chat/completions", json=body)
+        ns_text = resp_ns.json()["choices"][0]["message"]["content"]
+
+        body["stream"] = True
+        resp_s = client.post("/v1/chat/completions", json=body)
+        s_text, _ = _collect_stream_content(resp_s)
+
+        assert s_text == ns_text
+
+
+class TestStreamingStopSequenceCompletion:
+    """Completion endpoint: streaming stop should match non-streaming."""
+
+    def test_stop_single_word(self, client):
+        body = {
+            "prompt": "hello",
+            "max_tokens": 20,
+            "stop": ["fox"],
+        }
+        resp_ns = client.post("/v1/completions", json=body)
+        ns_text = resp_ns.json()["choices"][0]["text"]
+
+        body["stream"] = True
+        resp_s = client.post("/v1/completions", json=body)
+        s_text, s_fr = _collect_stream_content(resp_s)
+
+        assert s_text == ns_text
+        assert "fox" not in s_text
+        assert s_fr == "stop"
+
+    def test_stop_cross_token_boundary(self, client):
+        body = {
+            "prompt": "hello",
+            "max_tokens": 20,
+            "stop": ["wn f"],
+        }
+        resp_ns = client.post("/v1/completions", json=body)
+        ns_text = resp_ns.json()["choices"][0]["text"]
+
+        body["stream"] = True
+        resp_s = client.post("/v1/completions", json=body)
+        s_text, _ = _collect_stream_content(resp_s)
+
+        assert s_text == ns_text
+        assert "wn f" not in s_text


### PR DESCRIPTION
## Summary

Streaming endpoints emit tokens before fully detecting multi-character stop sequences, causing partial stop sequence characters to leak into output. This violates the OpenAI API contract where streaming and non-streaming should produce identical content.

## Changes

- **`_stream_chat()`**: Apply stop truncation on full text before streaming tokens
- **`_stream_completion()`**: Same fix for completions endpoint
- **`_stream_chat_scheduled()`**: Collect all scheduler tokens first, then truncate and stream
- **`tests/test_bugfix_25.py`**: 5 test cases verifying streaming/non-streaming output parity

## Test Results
All 199 tests pass. Lint clean.

Closes #25
Closes #34
Closes #45