### PR TITLE
fix: CLI arg priority broken — _TrackAction fails in subparser (#62)

### DIFF
--- a/src/xpyd_sim/cli.py
+++ b/src/xpyd_sim/cli.py
@@ -106,7 +106,11 @@ def _resolve_config(
     cli_args: argparse.Namespace,
     yaml_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Resolve config with priority: CLI > env vars > YAML > defaults."""
+    """Resolve config with priority: CLI > env vars > YAML > defaults.
+
+    All argparse args use default=None as a sentinel. A non-None value
+    means the user explicitly provided that argument on the CLI.
+    """
     result: dict[str, Any] = {}
 
     # Map CLI arg names to config keys
@@ -130,17 +134,11 @@ def _resolve_config(
     }
 
     for cli_attr, key in cli_to_key.items():
-        # 1. Check if CLI arg was explicitly provided
         cli_val = getattr(cli_args, cli_attr, None)
         default_val = _DEFAULTS[key]
-        # argparse sets unset args to their default — we use None defaults
-        # and check _explicitly_set to detect user intent
-        explicitly_set = key in getattr(cli_args, "_explicitly_set", set())
-        # For store_true flags like scheduling_enabled, check if truthy
-        if not explicitly_set and key == "scheduling_enabled" and cli_val is True:
-            explicitly_set = True
 
-        if explicitly_set:
+        # 1. CLI: non-None means explicitly set (all args default to None)
+        if cli_val is not None:
             result[key] = cli_val
             continue
 
@@ -165,51 +163,30 @@ def _resolve_config(
     return result
 
 
-class _TrackingNamespace(argparse.Namespace):
-    """Namespace that tracks which arguments were explicitly set on CLI."""
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self._explicitly_set: set[str] = set()
-
-
-class _TrackAction(argparse.Action):
-    """Custom action that records when an arg is explicitly provided."""
-
-    def __call__(  # type: ignore[override]
-        self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
-        values: Any, option_string: str | None = None,
-    ) -> None:
-        setattr(namespace, self.dest, values)
-        if hasattr(namespace, "_explicitly_set"):
-            namespace._explicitly_set.add(self.dest)
-
-
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="xpyd-sim", description="xPyD inference simulator")
     sub = parser.add_subparsers(dest="command")
 
     serve = sub.add_parser("serve", help="Start the unified simulator server")
-    serve.add_argument("--mode", choices=["dual", "prefill", "decode"], default="dual",
-                       action=_TrackAction)
-    serve.add_argument("--port", type=int, default=8000, action=_TrackAction)
-    serve.add_argument("--host", default="0.0.0.0", action=_TrackAction)
-    serve.add_argument("--model", default="dummy", action=_TrackAction)
-    serve.add_argument("--prefill-delay-ms", type=float, default=50.0, action=_TrackAction)
-    serve.add_argument("--kv-transfer-delay-ms", type=float, default=5.0, action=_TrackAction)
-    serve.add_argument("--decode-delay-per-token-ms", type=float, default=10.0,
-                       action=_TrackAction)
-    serve.add_argument("--eos-min-ratio", type=float, default=0.5, action=_TrackAction)
-    serve.add_argument("--max-model-len", type=int, default=131072, action=_TrackAction)
-    serve.add_argument("--warmup-requests", type=int, default=0, action=_TrackAction)
-    serve.add_argument("--warmup-penalty-ms", type=float, default=0.0, action=_TrackAction)
-    serve.add_argument("--log-requests", type=str, default=None, action=_TrackAction)
-    serve.add_argument("--profile", type=str, default=None, action=_TrackAction)
-    serve.add_argument("--config", type=str, default=None, help="YAML config file path",
-                       action=_TrackAction)
-    serve.add_argument("--max-num-batched-tokens", type=int, default=8192, action=_TrackAction)
-    serve.add_argument("--max-num-seqs", type=int, default=256, action=_TrackAction)
-    serve.add_argument("--scheduling", action="store_true", default=False,
+    # All defaults are None (sentinel) so _resolve_config can detect
+    # whether the user explicitly provided the argument.
+    serve.add_argument("--mode", choices=["dual", "prefill", "decode"], default=None)
+    serve.add_argument("--port", type=int, default=None)
+    serve.add_argument("--host", default=None)
+    serve.add_argument("--model", default=None)
+    serve.add_argument("--prefill-delay-ms", type=float, default=None)
+    serve.add_argument("--kv-transfer-delay-ms", type=float, default=None)
+    serve.add_argument("--decode-delay-per-token-ms", type=float, default=None)
+    serve.add_argument("--eos-min-ratio", type=float, default=None)
+    serve.add_argument("--max-model-len", type=int, default=None)
+    serve.add_argument("--warmup-requests", type=int, default=None)
+    serve.add_argument("--warmup-penalty-ms", type=float, default=None)
+    serve.add_argument("--log-requests", type=str, default=None)
+    serve.add_argument("--profile", type=str, default=None)
+    serve.add_argument("--config", type=str, default=None, help="YAML config file path")
+    serve.add_argument("--max-num-batched-tokens", type=int, default=None)
+    serve.add_argument("--max-num-seqs", type=int, default=None)
+    serve.add_argument("--scheduling", action="store_true", default=None,
                        dest="scheduling_enabled")
 
     # Calibrate subcommand
@@ -218,7 +195,7 @@ def main(argv: list[str] | None = None) -> None:
     cal.add_argument("--output", required=True, help="Path to write profile YAML")
     cal.add_argument("--plot", default=None, help="Path to write visualization PNG")
 
-    args = parser.parse_args(argv, namespace=_TrackingNamespace())
+    args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
         return

--- a/tests/test_m4_config.py
+++ b/tests/test_m4_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import textwrap
 from pathlib import Path
@@ -9,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from xpyd_sim.cli import _load_yaml_config, _resolve_config, _TrackingNamespace
+from xpyd_sim.cli import _load_yaml_config, _resolve_config
 
 
 @pytest.fixture()
@@ -42,6 +43,24 @@ def yaml_config_file(tmp_path: Path) -> Path:
     p = tmp_path / "config.yaml"
     p.write_text(config)
     return p
+
+
+def _make_ns(**overrides: object) -> argparse.Namespace:
+    """Create a Namespace with all CLI attrs set to None (sentinel) by default.
+
+    Non-None values simulate args that were explicitly provided on the CLI.
+    """
+    attrs = {
+        "mode": None, "port": None, "host": None, "model": None,
+        "prefill_delay_ms": None, "kv_transfer_delay_ms": None,
+        "decode_delay_per_token_ms": None, "eos_min_ratio": None,
+        "max_model_len": None, "warmup_requests": None,
+        "warmup_penalty_ms": None, "log_requests": None,
+        "profile": None, "max_num_batched_tokens": None,
+        "max_num_seqs": None, "scheduling_enabled": None,
+    }
+    attrs.update(overrides)
+    return argparse.Namespace(**attrs)
 
 
 class TestYAMLLoading:
@@ -84,17 +103,7 @@ class TestTC11_9_CLIOverridesYAML:
     def test_cli_overrides_yaml_mode(self, yaml_config_file: Path) -> None:
         """CLI --mode should override YAML mode."""
         yaml_cfg = _load_yaml_config(yaml_config_file)
-        ns = _TrackingNamespace()
-        ns.mode = "decode"
-        ns._explicitly_set = {"mode"}
-        # Set other attrs with defaults (not explicitly set)
-        for attr in (
-            "port", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns(mode="decode")  # CLI explicitly sets mode
 
         result = _resolve_config(ns, yaml_cfg)
         assert result["mode"] == "decode"  # CLI wins
@@ -102,16 +111,7 @@ class TestTC11_9_CLIOverridesYAML:
 
     def test_cli_overrides_yaml_port(self, yaml_config_file: Path) -> None:
         yaml_cfg = _load_yaml_config(yaml_config_file)
-        ns = _TrackingNamespace()
-        ns.port = 7777
-        ns._explicitly_set = {"port"}
-        for attr in (
-            "mode", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns(port=7777)  # CLI explicitly sets port
 
         result = _resolve_config(ns, yaml_cfg)
         assert result["port"] == 7777  # CLI wins
@@ -119,16 +119,7 @@ class TestTC11_9_CLIOverridesYAML:
 
     def test_cli_overrides_yaml_latency(self, yaml_config_file: Path) -> None:
         yaml_cfg = _load_yaml_config(yaml_config_file)
-        ns = _TrackingNamespace()
-        ns.prefill_delay_ms = 999.0
-        ns._explicitly_set = {"prefill_delay_ms"}
-        for attr in (
-            "mode", "port", "host", "model",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns(prefill_delay_ms=999.0)  # CLI explicitly sets
 
         result = _resolve_config(ns, yaml_cfg)
         assert result["prefill_delay_ms"] == 999.0  # CLI wins
@@ -141,15 +132,7 @@ class TestTC11_10_YAMLOnlyConfig:
     def test_yaml_only_all_settings(self, yaml_config_file: Path) -> None:
         """When no CLI args are explicitly set, all values come from YAML."""
         yaml_cfg = _load_yaml_config(yaml_config_file)
-        ns = _TrackingNamespace()
-        # Nothing explicitly set
-        for attr in (
-            "mode", "port", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns()  # All None — nothing explicitly set
 
         result = _resolve_config(ns, yaml_cfg)
         assert result["mode"] == "prefill"
@@ -172,15 +155,7 @@ class TestTC11_11_DefaultConfig:
 
     def test_all_defaults(self) -> None:
         """When nothing is provided, sensible defaults are used."""
-        ns = _TrackingNamespace()
-        for attr in (
-            "mode", "port", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
-
+        ns = _make_ns()
         result = _resolve_config(ns, yaml_config=None)
         assert result["mode"] == "dual"
         assert result["port"] == 8000
@@ -202,14 +177,7 @@ class TestEnvVarFallback:
 
     def test_env_var_overrides_yaml(self, yaml_config_file: Path) -> None:
         yaml_cfg = _load_yaml_config(yaml_config_file)
-        ns = _TrackingNamespace()
-        for attr in (
-            "mode", "port", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns()
 
         with patch.dict(os.environ, {"XPYD_SIM_PORT": "5555"}):
             result = _resolve_config(ns, yaml_cfg)
@@ -217,30 +185,14 @@ class TestEnvVarFallback:
         assert result["mode"] == "prefill"  # YAML still used for others
 
     def test_cli_overrides_env(self) -> None:
-        ns = _TrackingNamespace()
-        ns.port = 1234
-        ns._explicitly_set = {"port"}
-        for attr in (
-            "mode", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns(port=1234)
 
         with patch.dict(os.environ, {"XPYD_SIM_PORT": "5555"}):
             result = _resolve_config(ns)
         assert result["port"] == 1234  # CLI wins over env
 
     def test_env_overrides_default(self) -> None:
-        ns = _TrackingNamespace()
-        for attr in (
-            "mode", "port", "host", "model", "prefill_delay_ms",
-            "kv_transfer_delay_ms", "decode_delay_per_token_ms",
-            "eos_min_ratio", "max_model_len", "warmup_requests",
-            "warmup_penalty_ms", "log_requests", "profile",
-        ):
-            setattr(ns, attr, None)
+        ns = _make_ns()
 
         with patch.dict(os.environ, {"XPYD_SIM_MODE": "decode"}):
             result = _resolve_config(ns)
@@ -248,21 +200,40 @@ class TestEnvVarFallback:
 
 
 class TestCLIParsing:
-    """Test that CLI argument parsing correctly tracks explicitly-set args."""
+    """Test that CLI argument parsing correctly detects explicitly-set args."""
 
     def test_parse_with_explicit_args(self) -> None:
-        """Verify the full parse path tracks explicitly set args."""
-        # We test the argparse integration indirectly through main()
-        # by verifying the serve subcommand parses correctly
-        import argparse
+        """Verify argparse with None defaults: set args are non-None."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--mode", default=None)
+        parser.add_argument("--port", type=int, default=None)
 
-        from xpyd_sim.cli import _TrackAction, _TrackingNamespace
+        ns = parser.parse_args(["--mode", "prefill"])
+        assert ns.mode == "prefill"  # Set → non-None
+        assert ns.port is None  # Not set → None
+
+        result = _resolve_config(ns)
+        assert result["mode"] == "prefill"
+        assert result["port"] == 8000  # default
+
+    def test_subparser_preserves_explicit_args(self) -> None:
+        """Verify that subparser args are correctly detected as explicit.
+
+        This is the regression test for #62: _TrackAction failed in
+        subparsers because argparse uses a temporary namespace internally.
+        The new sentinel-based approach works correctly.
+        """
 
         parser = argparse.ArgumentParser()
-        parser.add_argument("--mode", default="dual", action=_TrackAction)
-        parser.add_argument("--port", type=int, default=8000, action=_TrackAction)
+        sub = parser.add_subparsers(dest="command")
+        serve = sub.add_parser("serve")
+        serve.add_argument("--mode", default=None)
+        serve.add_argument("--port", type=int, default=None)
 
-        ns = parser.parse_args(["--mode", "prefill"], namespace=_TrackingNamespace())
-        assert ns.mode == "prefill"
-        assert "mode" in ns._explicitly_set
-        assert "port" not in ns._explicitly_set
+        ns = parser.parse_args(["serve", "--mode", "prefill"])
+        assert ns.mode == "prefill"  # Explicitly set
+        assert ns.port is None  # Not set
+
+        result = _resolve_config(ns)
+        assert result["mode"] == "prefill"  # CLI wins
+        assert result["port"] == 8000  # default


### PR DESCRIPTION
## Problem

`_TrackAction` was designed to track which CLI args the user explicitly set, but **it never worked with argparse subparsers**. Python's argparse passes a temporary internal `Namespace` (not the custom `_TrackingNamespace`) to subparser actions, so `_explicitly_set` was always empty.

This caused **all CLI arguments to be silently ignored**:
- `--mode prefill` → ignored, `/health` returns `dual`
- `--max-model-len 65536` → ignored, `/v1/models` returns `131072`
- `--log-requests file.jsonl` → ignored, no file written
- `--config config.yaml --mode prefill` → YAML overrides CLI

## Fix

Replace the broken `_TrackAction`/`_TrackingNamespace`/`_explicitly_set` mechanism with the standard **sentinel pattern**: all argparse arguments use `default=None`. In `_resolve_config`, a non-None value means the user explicitly provided that argument.

This is simpler, has no moving parts, and works correctly with subparsers.

## Verification

Tested with real `subprocess.Popen` server starts (matching #61's reproduction):
- `--mode prefill` → `/health` returns `prefill` ✅
- `--mode decode` → `/health` returns `decode` ✅
- `--max-model-len 65536` → `/v1/models` returns `65536` ✅
- `--log-requests` → JSONL populated ✅
- `--scheduling` → `/debug/batch` + `/metrics` batch gauges ✅
- `--config yaml --mode prefill --prefill-delay-ms 200` → CLI overrides YAML ✅

219 tests pass.

Closes #61, closes #62