### PR TITLE
fix: expose batch metrics and /debug/batch in non-scheduling mode (#64)

### DIFF
--- a/src/xpyd_sim/server.py
+++ b/src/xpyd_sim/server.py
@@ -251,33 +251,46 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
 
     @app.get("/metrics")
     async def metrics():
-        extra = ""
         if config._scheduler:
             state = config._scheduler.get_batch_state()
-            extra = (
-                f"\n# HELP xpyd_sim_prefill_queue_depth Current prefill queue depth.\n"
-                f"# TYPE xpyd_sim_prefill_queue_depth gauge\n"
-                f"xpyd_sim_prefill_queue_depth {state['prefill_queue_depth']}\n"
-                f"# HELP xpyd_sim_prefill_batch_size Current prefill batch size.\n"
-                f"# TYPE xpyd_sim_prefill_batch_size gauge\n"
-                f"xpyd_sim_prefill_batch_size {state['prefill_batch_size']}\n"
-                f"# HELP xpyd_sim_decode_batch_size Current decode batch size.\n"
-                f"# TYPE xpyd_sim_decode_batch_size gauge\n"
-                f"xpyd_sim_decode_batch_size {state['decode_batch_size']}\n"
-                f"# HELP xpyd_sim_decode_avg_context_length "
-                f"Average context length in decode batch.\n"
-                f"# TYPE xpyd_sim_decode_avg_context_length gauge\n"
-                f"xpyd_sim_decode_avg_context_length {state['decode_avg_context_length']}\n"
-            )
+        else:
+            state = {
+                "prefill_queue_depth": 0,
+                "prefill_batch_size": 0,
+                "decode_batch_size": 0,
+                "decode_avg_context_length": 0.0,
+            }
+        batch_metrics = (
+            f"\n# HELP xpyd_sim_prefill_queue_depth Current prefill queue depth.\n"
+            f"# TYPE xpyd_sim_prefill_queue_depth gauge\n"
+            f"xpyd_sim_prefill_queue_depth {state['prefill_queue_depth']}\n"
+            f"# HELP xpyd_sim_prefill_batch_size Current prefill batch size.\n"
+            f"# TYPE xpyd_sim_prefill_batch_size gauge\n"
+            f"xpyd_sim_prefill_batch_size {state['prefill_batch_size']}\n"
+            f"# HELP xpyd_sim_decode_batch_size Current decode batch size.\n"
+            f"# TYPE xpyd_sim_decode_batch_size gauge\n"
+            f"xpyd_sim_decode_batch_size {state['decode_batch_size']}\n"
+            f"# HELP xpyd_sim_decode_avg_context_length "
+            f"Average context length in decode batch.\n"
+            f"# TYPE xpyd_sim_decode_avg_context_length gauge\n"
+            f"xpyd_sim_decode_avg_context_length {state['decode_avg_context_length']}\n"
+        )
         return PlainTextResponse(
-            config._metrics.render_prometheus() + extra,
+            config._metrics.render_prometheus() + batch_metrics,
             media_type="text/plain; version=0.0.4; charset=utf-8",
         )
 
     @app.get("/debug/batch")
     async def debug_batch():
         if not config._scheduler:
-            return {"error": "Scheduling not enabled"}
+            return {
+                "prefill_queue_depth": 0,
+                "prefill_batch_size": 0,
+                "prefill_batch_tokens": 0,
+                "decode_batch_size": 0,
+                "decode_avg_context_length": 0.0,
+                "decode_requests": [],
+            }
         return config._scheduler.get_batch_state()
 
     @app.get("/v1/models")

--- a/tests/test_m9_scheduling.py
+++ b/tests/test_m9_scheduling.py
@@ -588,14 +588,17 @@ async def test_tc13_12_e2e_pd_disaggregation():
 
 @pytest.mark.asyncio
 async def test_debug_batch_disabled():
-    """When scheduling is disabled, /debug/batch returns an error."""
+    """When scheduling is disabled, /debug/batch returns zero-state (not error)."""
     config = ServerConfig(scheduling_enabled=False)
     app = create_app(config)
     transport = ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/debug/batch")
         assert resp.status_code == 200
-        assert "error" in resp.json()
+        data = resp.json()
+        assert "prefill_queue_depth" in data
+        assert data["prefill_queue_depth"] == 0
+        assert data["decode_batch_size"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_regression_48_56.py
+++ b/tests/test_regression_48_56.py
@@ -533,3 +533,45 @@ class TestSchedulerSyncSafety:
         msg_type, msg = big_req.token_queue.get_nowait()
         assert msg_type == "error"
         assert "exceeds" in msg
+
+
+# ===================================================================
+# Issue #64 — Batch metrics and /debug/batch in non-scheduling mode
+# ===================================================================
+
+
+class TestBatchMetricsAlwaysPresent:
+    """Guard against batch metrics disappearing when scheduling is off."""
+
+    @pytest.mark.asyncio
+    async def test_metrics_has_batch_gauges_without_scheduling(self):
+        """#64: /metrics must include batch gauge metrics even without scheduling."""
+        config = ServerConfig(scheduling_enabled=False)
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.get("/metrics")
+            text = r.text
+            for metric in [
+                "xpyd_sim_prefill_queue_depth",
+                "xpyd_sim_prefill_batch_size",
+                "xpyd_sim_decode_batch_size",
+                "xpyd_sim_decode_avg_context_length",
+            ]:
+                assert metric in text, f"Missing metric: {metric}"
+
+    @pytest.mark.asyncio
+    async def test_debug_batch_returns_state_without_scheduling(self):
+        """#64: /debug/batch must return zero-state, not error, without scheduling."""
+        config = ServerConfig(scheduling_enabled=False)
+        app = create_app(config)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.get("/debug/batch")
+            assert r.status_code == 200
+            data = r.json()
+            assert "error" not in data, f"Should not return error: {data}"
+            assert "prefill_queue_depth" in data
+            assert data["decode_batch_size"] == 0


### PR DESCRIPTION
## Problem

`/metrics` omits batch gauge metrics and `/debug/batch` returns `{"error": "Scheduling not enabled"}` when the server starts without `--scheduling`. DESIGN.md lists these as required observability endpoints without qualifying them as scheduling-only.

## Fix

- `/metrics`: Always render batch gauges (`prefill_queue_depth`, `prefill_batch_size`, `decode_batch_size`, `decode_avg_context_length`). Values are 0 when scheduling is off, live state when on.
- `/debug/batch`: Return zero-state JSON (same schema as scheduler) instead of error when scheduling is off.

## Why

- Prometheus scrapers shouldn't see metrics appear/disappear based on mode
- Monitoring dashboards get consistent schema
- `/debug/batch` callers get predictable JSON without error handling

221 tests pass.

Closes #64