### PR TITLE
fix: prefill batch FIFO ordering (#65)

### DIFF
--- a/src/xpyd_sim/scheduler.py
+++ b/src/xpyd_sim/scheduler.py
@@ -332,7 +332,7 @@ class Scheduler:
         remaining: list[InferenceRequest] = []
         current_tokens = 0
 
-        for req in queue:
+        for i, req in enumerate(queue):
             if req.input_tokens > self.config.max_model_len:
                 # Reject: signal error directly (put_nowait and set are sync-safe)
                 req.token_queue.put_nowait(
@@ -345,11 +345,12 @@ class Scheduler:
                 req.done_event.set()
                 continue
             if current_tokens + req.input_tokens > self.config.max_num_batched_tokens:
-                remaining.append(req)
-                continue
+                # FIFO: stop here, all subsequent requests stay in queue
+                remaining.extend(queue[i:])
+                break
             if len(batch) >= self.config.max_num_seqs:
-                remaining.append(req)
-                continue
+                remaining.extend(queue[i:])
+                break
             batch.append(req)
             current_tokens += req.input_tokens
 

--- a/tests/test_regression_48_56.py
+++ b/tests/test_regression_48_56.py
@@ -575,3 +575,57 @@ class TestBatchMetricsAlwaysPresent:
             assert "error" not in data, f"Should not return error: {data}"
             assert "prefill_queue_depth" in data
             assert data["decode_batch_size"] == 0
+
+
+# ===================================================================
+# Issue #65 — Prefill batch FIFO ordering
+# ===================================================================
+
+
+class TestPrefillFIFO:
+    """Guard against prefill batch formation violating FIFO order."""
+
+    def test_large_request_blocks_subsequent(self):
+        """#65: When a request doesn't fit, all subsequent requests must
+        stay in the remaining queue (break, not continue)."""
+        from xpyd_sim.scheduler import InferenceRequest, Scheduler, SchedulingConfig
+
+        cfg = SchedulingConfig(
+            max_model_len=131072,
+            max_num_batched_tokens=4096,
+            max_num_seqs=256,
+            enabled=True,
+        )
+        s = Scheduler(config=cfg)
+
+        large = InferenceRequest(request_id="large", input_tokens=5000, max_tokens=1)
+        small = InferenceRequest(request_id="small", input_tokens=100, max_tokens=1)
+
+        batch, remaining = s._form_prefill_batch([large, small])
+
+        # large doesn't fit → FIFO break → small stays in remaining too
+        assert len(batch) == 0, f"Batch should be empty: {[r.request_id for r in batch]}"
+        remaining_ids = [r.request_id for r in remaining]
+        assert remaining_ids == ["large", "small"], (
+            f"FIFO violated: remaining={remaining_ids}"
+        )
+
+    def test_max_num_seqs_blocks_subsequent(self):
+        """#65: When max_num_seqs is reached, subsequent requests stay queued."""
+        from xpyd_sim.scheduler import InferenceRequest, Scheduler, SchedulingConfig
+
+        cfg = SchedulingConfig(
+            max_model_len=131072,
+            max_num_batched_tokens=131072,
+            max_num_seqs=2,
+            enabled=True,
+        )
+        s = Scheduler(config=cfg)
+
+        r1 = InferenceRequest(request_id="r1", input_tokens=100, max_tokens=1)
+        r2 = InferenceRequest(request_id="r2", input_tokens=100, max_tokens=1)
+        r3 = InferenceRequest(request_id="r3", input_tokens=100, max_tokens=1)
+
+        batch, remaining = s._form_prefill_batch([r1, r2, r3])
+        assert [r.request_id for r in batch] == ["r1", "r2"]
+        assert [r.request_id for r in remaining] == ["r3"]


### PR DESCRIPTION
DESIGN.md says `break` when batch is full, code used `continue` allowing queue jumping. Fixed to `break` + `remaining.extend(queue[i:])`.

223 tests pass. Closes #65