### PR TITLE
refactor: xpyd-proxy as optional e2e dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,16 @@ jobs:
         run: pip install -e ".[dev]"
       - name: Run tests
         run: pytest tests/ -v --tb=short --timeout=120
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev,e2e]"
+      - name: Run e2e tests
+        run: pytest tests/test_e2e_proxy.py -v --tb=short --timeout=120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "pytest-timeout>=2.3.0",
     "ruff>=0.3.0",
     "isort>=5.13.0",
+]
+e2e = [
     "xpyd>=1.1.0",
 ]
 

--- a/tests/test_e2e_proxy.py
+++ b/tests/test_e2e_proxy.py
@@ -4,6 +4,9 @@ Tests the full PD disaggregation flow:
   client → proxy → sim(prefill) → sim(decode) → client
 
 Validates response FORMAT (not content), both endpoints, streaming + non-streaming.
+
+Requires: pip install xpyd-sim[e2e]
+Run with: pytest tests/test_e2e_proxy.py -m e2e
 """
 
 from __future__ import annotations
@@ -14,13 +17,18 @@ import socket
 import threading
 import time
 
-import httpx
-import uvicorn
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from xpyd.proxy import Proxy, RoundRobinSchedulingPolicy
+pytest = __import__("pytest")
 
-from xpyd_sim.server import ServerConfig, create_app
+# Skip entire module if xpyd (proxy) is not installed
+xpyd = pytest.importorskip("xpyd", reason="xpyd-proxy not installed (pip install xpyd-sim[e2e])")
+
+import httpx  # noqa: E402
+import uvicorn  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
+from xpyd.proxy import Proxy, RoundRobinSchedulingPolicy  # noqa: E402
+
+from xpyd_sim.server import ServerConfig, create_app  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
Move `xpyd` from dev to `[e2e]` optional group. E2e tests auto-skip when proxy isn't installed.

CI: separate e2e job installs `.[dev,e2e]`. Unit tests unaffected.

Later when proxy publishes as `xpyd-proxy`, update the dep name here.