### PR TITLE
fix: e2e dep xpyd -> xpyd-proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
     "isort>=5.13.0",
 ]
 e2e = [
-    "xpyd>=1.1.0",
+    "xpyd-proxy>=1.2.0",
 ]
 
 [project.scripts]

--- a/tests/test_e2e_proxy.py
+++ b/tests/test_e2e_proxy.py
@@ -20,7 +20,7 @@ import time
 pytest = __import__("pytest")
 
 # Skip entire module if xpyd (proxy) is not installed
-xpyd = pytest.importorskip("xpyd", reason="xpyd-proxy not installed (pip install xpyd-sim[e2e])")
+xpyd = pytest.importorskip("xpyd", reason="xpyd-proxy not installed")
 
 import httpx  # noqa: E402
 import uvicorn  # noqa: E402


### PR DESCRIPTION
Change e2e optional dependency from `xpyd>=1.1.0` to `xpyd-proxy>=1.2.0`.

Avoids circular dependency when `xpyd` becomes a meta-package (xpyd → xpyd-sim + xpyd-proxy).